### PR TITLE
Minimize `dotnet` setup time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ addons:
     - libssl-dev
     - libunwind8
     - zlib1g
+env:
+  global:
+    - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+    - DOTNET_CLI_TELEMETRY_OPTOUT: 1    
 mono:
   - 4.0.5
 os:
@@ -25,4 +29,4 @@ branches:
 before_install:
   - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
 script:
-  - ./build.sh verify
+  - ./build.sh --quiet verify


### PR DESCRIPTION
Minimize `dotnet` setup time:
- disable telemetry; 
- build with `--quiet` 
- no need for caching.