### PR TITLE
Make DefaultIdentifierFactory return private setter

### DIFF
--- a/src/YesSql.Core/Data/DefaultIdentifierFactory.cs
+++ b/src/YesSql.Core/Data/DefaultIdentifierFactory.cs
@@ -25,7 +25,7 @@ namespace YesSql.Data
             var setType = typeof(Action<,>).MakeGenericType(new[] { tContainer, tProperty });
 
             var getter = propertyInfo.GetGetMethod().CreateDelegate(getType);
-            var setter = propertyInfo.GetSetMethod().CreateDelegate(setType);
+            var setter = propertyInfo.GetSetMethod(true).CreateDelegate(setType);
 
             var accessorType = typeof(IdAccessor<,>).MakeGenericType(tContainer, tProperty);
 

--- a/test/YesSql.Tests/CoreTests.cs
+++ b/test/YesSql.Tests/CoreTests.cs
@@ -2573,5 +2573,28 @@ namespace YesSql.Tests
 
             Console.WriteLine($"Gated: {gatedCounter} NonGated: {nonGatedCounter}");
         }
+
+        [Fact]
+        public virtual async Task ShouldPopulateIdFieldWithPrivateSetter()
+        {
+            Tree oak;
+
+            using (var session = _store.CreateSession())
+            {
+                oak = new Tree
+                {
+                    Type = "Oak",
+                    HeightInInches = 375
+                };
+
+                session.Save(oak);
+            }
+
+            using (var session = _store.CreateSession())
+            {
+                Assert.Equal(0, oak.Id);
+                Assert.NotEqual(0, (await session.Query<Tree>().FirstOrDefaultAsync()).Id);
+            }
+        }
     }
 }

--- a/test/YesSql.Tests/CoreTests.cs
+++ b/test/YesSql.Tests/CoreTests.cs
@@ -2592,8 +2592,7 @@ namespace YesSql.Tests
 
             using (var session = _store.CreateSession())
             {
-                Assert.Equal(0, oak.Id);
-                Assert.NotEqual(0, (await session.Query<Tree>().FirstOrDefaultAsync()).Id);
+                Assert.Equal(oak.Id, (await session.Query<Tree>().FirstOrDefaultAsync()).Id);
             }
         }
     }

--- a/test/YesSql.Tests/Models/Tree.cs
+++ b/test/YesSql.Tests/Models/Tree.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace YesSql.Tests.Models
+{
+    public class Tree
+    {
+        public int Id { get; private set; }
+
+        public string Type { get; set; }
+
+        public int HeightInInches { get; set; }
+    }
+}


### PR DESCRIPTION
This change allows the id accessors to set a private "Id" field on an object. This allows for the creation of immutable entities that can be rehydrated from the store since the Id property setter is no longer required to be public.