### PR TITLE
Supporting bigint as primary key

### DIFF
--- a/src/YesSql.Abstractions/ISqlDialect.cs
+++ b/src/YesSql.Abstractions/ISqlDialect.cs
@@ -20,6 +20,7 @@ namespace YesSql
         bool HasDataTypeInIdentityColumn { get; }
         bool SupportsIdentityColumns { get; }
         string IdentityColumnString { get; }
+        string BigIntIdentityColumnString { get; }
         string IdentitySelectString { get; }
         string GetTypeName(DbType dbType, int? length, byte precision, byte scale);
         string GetSqlValue(object value);

--- a/src/YesSql.Core/Sql/BaseComandInterpreter.cs
+++ b/src/YesSql.Core/Sql/BaseComandInterpreter.cs
@@ -257,7 +257,7 @@ namespace YesSql.Sql
             // append identity if handled
             if (command.IsIdentity && _dialect.SupportsIdentityColumns)
             {
-                builder.Append(Space).Append(_dialect.IdentityColumnString);
+                builder.Append(Space).Append(command.DbType == DbType.Int64? _dialect.BigIntIdentityColumnString : _dialect.IdentityColumnString);
             }
 
             // [default value]

--- a/src/YesSql.Provider.Common/BaseDialect.cs
+++ b/src/YesSql.Provider.Common/BaseDialect.cs
@@ -46,6 +46,8 @@ namespace YesSql.Provider
 
         public virtual string IdentityColumnString => "[int] IDENTITY(1,1) primary key";
 
+        public virtual string BigIntIdentityColumnString => "[bigint] IDENTITY(1,1) primary key";
+
         public virtual string NullColumnString => String.Empty;
 
         public virtual string PrimaryKeyString => "primary key";

--- a/src/YesSql.Provider.MySql/MySqlDialect.cs
+++ b/src/YesSql.Provider.MySql/MySqlDialect.cs
@@ -36,6 +36,7 @@ namespace YesSql.Provider.MySql
         public override string Name => "MySql";
         public override string IdentitySelectString => "; select LAST_INSERT_ID()";
         public override string IdentityColumnString => "int AUTO_INCREMENT primary key";
+        public override string BigIntIdentityColumnString => "bigint AUTO_INCREMENT primary key";
         public override bool SupportsIfExistsBeforeTableName => true;
         
         public override string GetTypeName(DbType dbType, int? length, byte precision, byte scale)

--- a/src/YesSql.Provider.PostgreSql/PostgreSqlDialect.cs
+++ b/src/YesSql.Provider.PostgreSql/PostgreSqlDialect.cs
@@ -50,6 +50,7 @@ namespace YesSql.Provider.PostgreSql
         public override string NotInOperator(string values) => " <> all(array[" + values + "])";
         public override string IdentitySelectString => "RETURNING ";
         public override string IdentityColumnString => "SERIAL PRIMARY KEY";
+        public override string BigIntIdentityColumnString => "BIGSERIAL PRIMARY KEY";
         public override bool SupportsIfExistsBeforeTableName => true;
         public override bool PrefixIndex => true;
 

--- a/src/YesSql.Provider.Sqlite/SqliteDialect.cs
+++ b/src/YesSql.Provider.Sqlite/SqliteDialect.cs
@@ -49,6 +49,7 @@ namespace YesSql.Provider.Sqlite
         public override string Name => "Sqlite";
 
         public override string IdentityColumnString => "integer primary key autoincrement";
+        public override string BigIntIdentityColumnString => "BIGINT primary key autoincrement";
 
         public override string IdentitySelectString => "; select last_insert_rowid()";
 


### PR DESCRIPTION
            SchemaBuilder.CreateTable(nameof(Sample), table => table
                .Column<long>("SampleId", col => col.Identity().PrimaryKey())
                .Column<string>("Value", col => col.WithLength(200))
            );

generate a table with int primary key instead of bigint primary key.
