### PR TITLE
fix bug in saving data

### DIFF
--- a/src/YesSql.Core/Session.cs
+++ b/src/YesSql.Core/Session.cs
@@ -476,49 +476,58 @@ namespace YesSql
                 return;
             }
 
-            _flushing = true;
-
-            // we only check if the session is disposed if 
-            // there are no commands to commit.
-
-            CheckDisposed();
-
-            // saving all updated entities
-            foreach (var obj in _updated)
+            try
             {
-                if (!_deleted.Contains(obj))
+                _flushing = true;
+
+                // we only check if the session is disposed if 
+                // there are no commands to commit.
+
+                CheckDisposed();
+
+                // saving all updated entities
+                foreach (var obj in _updated)
                 {
-                    await UpdateEntityAsync(obj);
+                    if (!_deleted.Contains(obj))
+                    {
+                        await UpdateEntityAsync(obj);
+                    }
                 }
-            }
 
-            // saving all pending entities
-            foreach (var obj in _saved)
+                // saving all pending entities
+                foreach (var obj in _saved)
+                {
+                    await SaveEntityAsync(obj);
+                }
+
+                // deleting all pending entities
+                foreach (var obj in _deleted)
+                {
+                    await DeleteEntityAsync(obj);
+                }
+
+                // compute all reduce indexes
+                await ReduceAsync();
+
+                await DemandAsync();
+
+                foreach (var command in _commands.OrderBy(x => x.ExecutionOrder))
+                {
+                    await command.ExecuteAsync(_connection, _transaction, _dialect, Store.Configuration.Logger);
+                }
+
+                _updated.Clear();
+                _saved.Clear();
+                _deleted.Clear();
+                _commands.Clear();
+                _maps.Clear();
+            }
+            catch
             {
-                await SaveEntityAsync(obj);
+                _flushing = false;
+                throw;
             }
 
-            // deleting all pending entities
-            foreach (var obj in _deleted)
-            {
-                await DeleteEntityAsync(obj);
-            }
-
-            // compute all reduce indexes
-            await ReduceAsync();
-
-            await DemandAsync();
-
-            foreach (var command in _commands.OrderBy(x => x.ExecutionOrder))
-            {
-                await command.ExecuteAsync(_connection, _transaction, _dialect, Store.Configuration.Logger);
-            }
-
-            _updated.Clear();
-            _saved.Clear();
-            _deleted.Clear();
-            _commands.Clear();
-            _maps.Clear();
             _flushing = false;
         }
 

--- a/src/YesSql.Core/Session.cs
+++ b/src/YesSql.Core/Session.cs
@@ -524,11 +524,12 @@ namespace YesSql
             }
             catch
             {
-                _flushing = false;
                 throw;
             }
-
-            _flushing = false;
+            finally
+            {
+                _flushing = false;
+            }
         }
 
         public async Task CommitAsync()


### PR DESCRIPTION
If an exception happens during saving the data, the _flashing flag stays
true and while there is a session-pooling (and the last session has _flashing=true flag), the next operations will not save data.

### How to reproduce

- Save a document that raises an exception, (for example, by setting too long string for value of one of the indexes)

- try to create a new Session from the same  Store and save another object. (Assuming the Store use the previous Session of the Session-Pool, the second object will be never saved as the _flashing flag stayed true