### PR TITLE
Added ReverseLookup to TypeService

### DIFF
--- a/src/YesSql.Abstractions/ITypeService.cs
+++ b/src/YesSql.Abstractions/ITypeService.cs
@@ -1,9 +1,16 @@
 using System;
+using System.Collections.Generic;
 
 namespace YesSql
 {
     public interface ITypeService
     {
-         string this[Type t] { get; set; }
+        string this[Type t] { get; set; }
+
+        IEnumerable<Type> Keys { get; }
+
+        IEnumerable<string> Values { get; }
+
+        Type ReverseLookup(string value);
     }
 }

--- a/src/YesSql.Abstractions/ITypeService.cs
+++ b/src/YesSql.Abstractions/ITypeService.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 
 namespace YesSql
 {
@@ -7,10 +6,6 @@ namespace YesSql
     {
         string this[Type t] { get; set; }
 
-        IEnumerable<Type> Keys { get; }
-
-        IEnumerable<string> Values { get; }
-
-        Type ReverseLookup(string value);
+        Type this[string s] { get; }
     }
 }

--- a/src/YesSql.Core/Services/TypeService.cs
+++ b/src/YesSql.Core/Services/TypeService.cs
@@ -43,7 +43,7 @@ namespace YesSql.Services
             {
                 if (s == "dynamic")
                 {
-                    return null;
+                    return typeof(object);
                 }
 
                 return nameTypes[s];

--- a/src/YesSql.Core/Services/TypeService.cs
+++ b/src/YesSql.Core/Services/TypeService.cs
@@ -23,10 +23,10 @@ namespace YesSql.Services
                     }
 
                     var customName = typeInfo.GetCustomAttribute<SimplifiedTypeName>();
-                    var actualName = String.IsNullOrEmpty(customName?.Name) ? String.Concat(type.FullName, ", ", typeInfo.Assembly.GetName().Name) : customName.Name;
-                    nameTypes[actualName] = t;
+                    var calculatedName = String.IsNullOrEmpty(customName?.Name) ? $"{type.FullName}, {typeInfo.Assembly.GetName().Name}" : customName.Name;
+                    nameTypes[calculatedName] = t;
 
-                    return actualName;
+                    return calculatedName;
                 });
             }
 

--- a/src/YesSql.Core/Services/TypeService.cs
+++ b/src/YesSql.Core/Services/TypeService.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Reflection;
 
 namespace YesSql.Services
@@ -10,20 +9,6 @@ namespace YesSql.Services
         private readonly ConcurrentDictionary<Type, string> typeNames = new ConcurrentDictionary<Type, string>();
 
         private readonly ConcurrentDictionary<string, Type> nameTypes = new ConcurrentDictionary<string, Type>();
-
-        public IEnumerable<Type> Keys { get { return typeNames.Keys; } }
-
-        public IEnumerable<string> Values { get { return typeNames.Values; } }
-
-        public Type ReverseLookup(string value)
-        {
-            if (value == "dynamic")
-            {
-                return null;
-            }
-
-            return nameTypes[value];
-        }
 
         public string this[Type t]
         {
@@ -49,6 +34,19 @@ namespace YesSql.Services
             {
                 typeNames[t] = value;
                 nameTypes[value] = t;
+            }
+        }
+
+        public Type this[string s]
+        {
+            get
+            {
+                if (s == "dynamic")
+                {
+                    return null;
+                }
+
+                return nameTypes[s];
             }
         }
 

--- a/src/YesSql.Core/Services/TypeService.cs
+++ b/src/YesSql.Core/Services/TypeService.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
 namespace YesSql.Services
@@ -10,20 +9,27 @@ namespace YesSql.Services
     {
         private readonly ConcurrentDictionary<Type, string> typeNames = new ConcurrentDictionary<Type, string>();
 
+        private readonly ConcurrentDictionary<string, Type> nameTypes = new ConcurrentDictionary<string, Type>();
+
         public IEnumerable<Type> Keys { get { return typeNames.Keys; } }
 
         public IEnumerable<string> Values { get { return typeNames.Values; } }
 
         public Type ReverseLookup(string value)
         {
-            return typeNames.FirstOrDefault(t => t.Value == value).Key;
+            if (value == "dynamic")
+            {
+                return null;
+            }
+
+            return nameTypes[value];
         }
 
         public string this[Type t]
         {
             get
             {
-                return typeNames.GetOrAdd(t, type => 
+                return typeNames.GetOrAdd(t, type =>
                 {
                     var typeInfo = t.GetTypeInfo();
                     if (IsAnonymousType(typeInfo))
@@ -32,14 +38,17 @@ namespace YesSql.Services
                     }
 
                     var customName = typeInfo.GetCustomAttribute<SimplifiedTypeName>();
+                    var actualName = String.IsNullOrEmpty(customName?.Name) ? String.Concat(type.FullName, ", ", typeInfo.Assembly.GetName().Name) : customName.Name;
+                    nameTypes[actualName] = t;
 
-                    return String.IsNullOrEmpty(customName?.Name) ? String.Concat(type.FullName, ", ", typeInfo.Assembly.GetName().Name) : customName.Name;
+                    return actualName;
                 });
             }
 
             set
             {
                 typeNames[t] = value;
+                nameTypes[value] = t;
             }
         }
 

--- a/src/YesSql.Core/Services/TypeService.cs
+++ b/src/YesSql.Core/Services/TypeService.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 namespace YesSql.Services
@@ -7,6 +9,15 @@ namespace YesSql.Services
     public class TypeService : ITypeService
     {
         private readonly ConcurrentDictionary<Type, string> typeNames = new ConcurrentDictionary<Type, string>();
+
+        public IEnumerable<Type> Keys { get { return typeNames.Keys; } }
+
+        public IEnumerable<string> Values { get { return typeNames.Values; } }
+
+        public Type ReverseLookup(string value)
+        {
+            return typeNames.FirstOrDefault(t => t.Value == value).Key;
+        }
 
         public string this[Type t]
         {

--- a/src/YesSql.Core/Session.cs
+++ b/src/YesSql.Core/Session.cs
@@ -355,7 +355,7 @@ namespace YesSql
                     // If no type is specified, use the one from the document
                     if (typeof(T) == typeof(object))
                     {
-                        var itemType = Type.GetType(d.Type) ?? typeof(object);
+                        var itemType = Store.TypeNames.ReverseLookup(d.Type) ?? Type.GetType(d.Type) ?? typeof(object);  // I don't think the Type.GetType(d.Type) is necessary, but I left it in as a precaution
                         accessor = _store.GetIdAccessor(itemType, "Id");
 
                         item = (T)Store.Configuration.ContentSerializer.Deserialize(d.Content, itemType);

--- a/src/YesSql.Core/Session.cs
+++ b/src/YesSql.Core/Session.cs
@@ -355,7 +355,7 @@ namespace YesSql
                     // If no type is specified, use the one from the document
                     if (typeof(T) == typeof(object))
                     {
-                        var itemType = Store.TypeNames.ReverseLookup(d.Type) ?? typeof(object);
+                        var itemType = Store.TypeNames[d.Type] ?? typeof(object);
                         accessor = _store.GetIdAccessor(itemType, "Id");
 
                         item = (T)Store.Configuration.ContentSerializer.Deserialize(d.Content, itemType);

--- a/src/YesSql.Core/Session.cs
+++ b/src/YesSql.Core/Session.cs
@@ -355,7 +355,7 @@ namespace YesSql
                     // If no type is specified, use the one from the document
                     if (typeof(T) == typeof(object))
                     {
-                        var itemType = Store.TypeNames.ReverseLookup(d.Type) ?? Type.GetType(d.Type) ?? typeof(object);  // I don't think the Type.GetType(d.Type) is necessary, but I left it in as a precaution
+                        var itemType = Store.TypeNames.ReverseLookup(d.Type) ?? typeof(object);
                         accessor = _store.GetIdAccessor(itemType, "Id");
 
                         item = (T)Store.Configuration.ContentSerializer.Deserialize(d.Content, itemType);

--- a/src/YesSql.Core/Session.cs
+++ b/src/YesSql.Core/Session.cs
@@ -355,7 +355,7 @@ namespace YesSql
                     // If no type is specified, use the one from the document
                     if (typeof(T) == typeof(object))
                     {
-                        var itemType = Store.TypeNames[d.Type] ?? typeof(object);
+                        var itemType = Store.TypeNames[d.Type];
                         accessor = _store.GetIdAccessor(itemType, "Id");
 
                         item = (T)Store.Configuration.ContentSerializer.Deserialize(d.Content, itemType);

--- a/test/YesSql.Tests/CoreTests.cs
+++ b/test/YesSql.Tests/CoreTests.cs
@@ -136,6 +136,8 @@ namespace YesSql.Tests
                     transaction.Commit();
                 }
             }
+
+            _store.TypeNames[typeof(Person)] = "People";
         }
 
         [Fact]
@@ -3564,6 +3566,36 @@ namespace YesSql.Tests
                 await Assert.ThrowsAnyAsync<Exception>(() => session.CommitAsync());
 
                 Assert.Empty(session._commands);
+            }
+        }
+
+        [Fact]
+        public async Task ShouldResolveManyTypes()
+        {
+            using (var session = _store.CreateSession())
+            {
+                var bill = new Person
+                {
+                    Firstname = "Bill",
+                    Lastname = "Gates"
+                };
+
+                var lion = new Animal
+                {
+                    Name = "Lion"
+                };
+
+                session.Save(bill);
+                session.Save(lion);
+            }
+
+            using (var session = _store.CreateSession())
+            {
+                var all = await session.Query().Any().ListAsync();
+
+                Assert.Equal(2, all.Count());
+                Assert.Contains(all, x => x is Person);
+                Assert.Contains(all, x => x is Animal);
             }
         }
     }


### PR DESCRIPTION
This is required to fix a bug when queries do not specify a type.

I don't know if the method should call FirstOrDefault() or SingleOrDefault().
I used FirstOrDefault for safety.  But I feel Single is more correct.  There should never be more than one type mapped to the same value.

#183 