### PR TITLE
Fixes drop index sql dialect

### DIFF
--- a/src/YesSql.Abstractions/ISqlDialect.cs
+++ b/src/YesSql.Abstractions/ISqlDialect.cs
@@ -25,6 +25,7 @@ namespace YesSql
         string GetSqlValue(object value);
         string QuoteForTableName(string v);
         string GetDropTableString(string name);
+        string GetDropIndexString(string indexName, string tableName);
         string QuoteForColumnName(string columnName);
         string InOperator(string values);
         string InSelectOperator(string query);

--- a/src/YesSql.Core/Sql/BaseComandInterpreter.cs
+++ b/src/YesSql.Core/Sql/BaseComandInterpreter.cs
@@ -203,9 +203,7 @@ namespace YesSql.Sql
 
         public virtual void Run(StringBuilder builder, IDropIndexCommand command)
         {
-            builder.AppendFormat("drop index {0} ON {1}",
-                _dialect.QuoteForColumnName(command.IndexName),
-                _dialect.QuoteForTableName(command.Name));
+            builder.Append(_dialect.GetDropIndexString(command.IndexName, command.Name));
         }
 
         public virtual IEnumerable<string> Run(ISqlStatementCommand command)

--- a/src/YesSql.Provider.Common/BaseDialect.cs
+++ b/src/YesSql.Provider.Common/BaseDialect.cs
@@ -89,6 +89,8 @@ namespace YesSql.Provider
         }
 
         public virtual bool SupportsIfExistsBeforeTableName => false;
+        public virtual bool SupportsIfExistsBeforeIndexName => true;
+        public virtual bool SupportsTableNameAfterIndexName => true;
         public virtual string CascadeConstraintsString => String.Empty;
         public virtual bool SupportsIfExistsAfterTableName => false;
         public virtual string GetDropTableString(string name)
@@ -104,6 +106,24 @@ namespace YesSql.Provider
             if (SupportsIfExistsAfterTableName)
             {
                 sb.Append(" if exists");
+            }
+
+            return sb.ToString();
+        }
+        public virtual string GetDropIndexString(string indexName, string tableName)
+        {
+
+            var sb = new StringBuilder("drop index ");
+            if (SupportsIfExistsBeforeIndexName)
+            {
+                sb.Append("if exists ");
+            }
+
+            sb.Append(QuoteForColumnName(indexName));
+
+            if (SupportsTableNameAfterIndexName)
+            {
+                sb.AppendFormat(" {0}", QuoteForTableName(tableName));
             }
 
             return sb.ToString();

--- a/src/YesSql.Provider.Common/BaseDialect.cs
+++ b/src/YesSql.Provider.Common/BaseDialect.cs
@@ -89,8 +89,6 @@ namespace YesSql.Provider
         }
 
         public virtual bool SupportsIfExistsBeforeTableName => false;
-        public virtual bool SupportsIfExistsBeforeIndexName => true;
-        public virtual bool SupportsTableNameAfterIndexName => true;
         public virtual string CascadeConstraintsString => String.Empty;
         public virtual bool SupportsIfExistsAfterTableName => false;
         public virtual string GetDropTableString(string name)
@@ -110,25 +108,7 @@ namespace YesSql.Provider
 
             return sb.ToString();
         }
-        public virtual string GetDropIndexString(string indexName, string tableName)
-        {
-
-            var sb = new StringBuilder("drop index ");
-            if (SupportsIfExistsBeforeIndexName)
-            {
-                sb.Append("if exists ");
-            }
-
-            sb.Append(QuoteForColumnName(indexName));
-
-            if (SupportsTableNameAfterIndexName)
-            {
-                sb.AppendFormat(" on {0}", QuoteForTableName(tableName));
-            }
-
-            return sb.ToString();
-        }
-
+        public abstract string GetDropIndexString(string indexName, string tableName);
         public abstract string QuoteForColumnName(string columnName);
         public abstract string QuoteForTableName(string tableName);
 

--- a/src/YesSql.Provider.Common/BaseDialect.cs
+++ b/src/YesSql.Provider.Common/BaseDialect.cs
@@ -123,7 +123,7 @@ namespace YesSql.Provider
 
             if (SupportsTableNameAfterIndexName)
             {
-                sb.AppendFormat(" {0}", QuoteForTableName(tableName));
+                sb.AppendFormat(" on {0}", QuoteForTableName(tableName));
             }
 
             return sb.ToString();

--- a/src/YesSql.Provider.MySql/MySqlDialect.cs
+++ b/src/YesSql.Provider.MySql/MySqlDialect.cs
@@ -123,12 +123,7 @@ namespace YesSql.Provider.MySql
         public override string GetDropIndexString(string indexName, string tableName)
         {
             // This is dependent on version of MySql < v10.1.4 does not support IF EXISTS
-            var sb = new StringBuilder("drop index ")
-                .Append(QuoteForColumnName(indexName))
-                .Append(" on ")
-                .Append(QuoteForTableName(tableName));
-
-            return sb.ToString();
+            return "drop index " + QuoteForColumnName(indexName) + " on " + QuoteForTableName(tableName);
         }
 
         public override string QuoteForColumnName(string columnName)

--- a/src/YesSql.Provider.MySql/MySqlDialect.cs
+++ b/src/YesSql.Provider.MySql/MySqlDialect.cs
@@ -38,6 +38,9 @@ namespace YesSql.Provider.MySql
         public override string IdentityColumnString => "int AUTO_INCREMENT primary key";
         public override bool SupportsIfExistsBeforeTableName => true;
 
+        // This is dependent on version of MySql < v10.1.4 does not support IF EXISTS
+        public override bool SupportsIfExistsBeforeIndexName => false;
+
         public override string GetTypeName(DbType dbType, int? length, byte precision, byte scale)
         {
             if (length.HasValue)

--- a/src/YesSql.Provider.MySql/MySqlDialect.cs
+++ b/src/YesSql.Provider.MySql/MySqlDialect.cs
@@ -38,9 +38,6 @@ namespace YesSql.Provider.MySql
         public override string IdentityColumnString => "int AUTO_INCREMENT primary key";
         public override bool SupportsIfExistsBeforeTableName => true;
 
-        // This is dependent on version of MySql < v10.1.4 does not support IF EXISTS
-        public override bool SupportsIfExistsBeforeIndexName => false;
-
         public override string GetTypeName(DbType dbType, int? length, byte precision, byte scale)
         {
             if (length.HasValue)
@@ -121,6 +118,17 @@ namespace YesSql.Provider.MySql
                     sqlBuilder.Trail(offset);
                 }
             }
+        }
+
+        public override string GetDropIndexString(string indexName, string tableName)
+        {
+            // This is dependent on version of MySql < v10.1.4 does not support IF EXISTS
+            var sb = new StringBuilder("drop index ")
+                .Append(QuoteForColumnName(indexName))
+                .Append(" on ")
+                .Append(QuoteForTableName(tableName));
+
+            return sb.ToString();
         }
 
         public override string QuoteForColumnName(string columnName)

--- a/src/YesSql.Provider.PostgreSql/PostgreSqlDialect.cs
+++ b/src/YesSql.Provider.PostgreSql/PostgreSqlDialect.cs
@@ -50,6 +50,7 @@ namespace YesSql.Provider.PostgreSql
         public override string NotInOperator(string values) => " <> all(array[" + values + "])";
         public override string IdentitySelectString => "RETURNING ";
         public override string IdentityColumnString => "SERIAL PRIMARY KEY";
+        public override bool SupportsIfExistsBeforeTableName => true;
         public override bool PrefixIndex => true;
         public override bool SupportsTableNameAfterIndexName => false;
 

--- a/src/YesSql.Provider.PostgreSql/PostgreSqlDialect.cs
+++ b/src/YesSql.Provider.PostgreSql/PostgreSqlDialect.cs
@@ -50,8 +50,8 @@ namespace YesSql.Provider.PostgreSql
         public override string NotInOperator(string values) => " <> all(array[" + values + "])";
         public override string IdentitySelectString => "RETURNING ";
         public override string IdentityColumnString => "SERIAL PRIMARY KEY";
-        public override bool SupportsIfExistsBeforeTableName => true;
         public override bool PrefixIndex => true;
+        public override bool SupportsTableNameAfterIndexName => false;
 
         public override string GetTypeName(DbType dbType, int? length, byte precision, byte scale)
         {

--- a/src/YesSql.Provider.PostgreSql/PostgreSqlDialect.cs
+++ b/src/YesSql.Provider.PostgreSql/PostgreSqlDialect.cs
@@ -131,10 +131,7 @@ namespace YesSql.Provider.PostgreSql
 
         public override string GetDropIndexString(string indexName, string tableName)
         {
-            var sb = new StringBuilder("drop index if exists ")
-                .Append(QuoteForColumnName(indexName));
-
-            return sb.ToString();
+            return "drop index if exists " + QuoteForColumnName(indexName);
         }
 
         public override string QuoteForColumnName(string columnName)

--- a/src/YesSql.Provider.PostgreSql/PostgreSqlDialect.cs
+++ b/src/YesSql.Provider.PostgreSql/PostgreSqlDialect.cs
@@ -52,7 +52,6 @@ namespace YesSql.Provider.PostgreSql
         public override string IdentityColumnString => "SERIAL PRIMARY KEY";
         public override bool SupportsIfExistsBeforeTableName => true;
         public override bool PrefixIndex => true;
-        public override bool SupportsTableNameAfterIndexName => false;
 
         public override string GetTypeName(DbType dbType, int? length, byte precision, byte scale)
         {
@@ -128,6 +127,14 @@ namespace YesSql.Provider.PostgreSql
                 sqlBuilder.Trail(" offset ");
                 sqlBuilder.Trail(offset);
             }
+        }
+
+        public override string GetDropIndexString(string indexName, string tableName)
+        {
+            var sb = new StringBuilder("drop index if exists ")
+                .Append(QuoteForColumnName(indexName));
+
+            return sb.ToString();
         }
 
         public override string QuoteForColumnName(string columnName)

--- a/src/YesSql.Provider.SqlServer/SqlServerDialect.cs
+++ b/src/YesSql.Provider.SqlServer/SqlServerDialect.cs
@@ -122,6 +122,16 @@ namespace YesSql.Provider.SqlServer
             }
         }
 
+        public override string GetDropIndexString(string indexName, string tableName)
+        {
+            var sb = new StringBuilder("drop index if exists ")
+                .Append(QuoteForColumnName(indexName))
+                .Append(" on ")
+                .Append(QuoteForTableName(tableName));
+
+            return sb.ToString();
+        }
+
         public override string QuoteForColumnName(string columnName)
         {
             return "[" + columnName + "]";

--- a/src/YesSql.Provider.SqlServer/SqlServerDialect.cs
+++ b/src/YesSql.Provider.SqlServer/SqlServerDialect.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Text;
 using YesSql.Sql;
 
 namespace YesSql.Provider.SqlServer

--- a/src/YesSql.Provider.SqlServer/SqlServerDialect.cs
+++ b/src/YesSql.Provider.SqlServer/SqlServerDialect.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Text;
 using YesSql.Sql;
 
 namespace YesSql.Provider.SqlServer
@@ -124,12 +123,7 @@ namespace YesSql.Provider.SqlServer
 
         public override string GetDropIndexString(string indexName, string tableName)
         {
-            var sb = new StringBuilder("drop index if exists ")
-                .Append(QuoteForColumnName(indexName))
-                .Append(" on ")
-                .Append(QuoteForTableName(tableName));
-
-            return sb.ToString();
+            return "drop index if exists " + QuoteForColumnName(indexName) + " on " + QuoteForTableName(tableName);
         }
 
         public override string QuoteForColumnName(string columnName)

--- a/src/YesSql.Provider.Sqlite/SqliteDialect.cs
+++ b/src/YesSql.Provider.Sqlite/SqliteDialect.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Text;
 using YesSql.Sql;
 
 namespace YesSql.Provider.Sqlite
@@ -52,8 +53,6 @@ namespace YesSql.Provider.Sqlite
 
         public override string IdentitySelectString => "; select last_insert_rowid()";
 
-        public override bool SupportsTableNameAfterIndexName => false;
-
         public override string GetTypeName(DbType dbType, int? length, byte precision, byte scale)
         {
             if (ColumnTypes.TryGetValue(dbType, out string value))
@@ -85,6 +84,14 @@ namespace YesSql.Provider.Sqlite
                 sqlBuilder.Trail(" OFFSET ");
                 sqlBuilder.Trail(offset);
             }
+        }
+
+        public override string GetDropIndexString(string indexName, string tableName)
+        {
+            var sb = new StringBuilder("drop index if exists ")
+                .Append(QuoteForColumnName(indexName));
+
+            return sb.ToString();
         }
 
         public override string QuoteForColumnName(string columnName)

--- a/src/YesSql.Provider.Sqlite/SqliteDialect.cs
+++ b/src/YesSql.Provider.Sqlite/SqliteDialect.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Text;
 using YesSql.Sql;
 
 namespace YesSql.Provider.Sqlite
@@ -88,10 +87,7 @@ namespace YesSql.Provider.Sqlite
 
         public override string GetDropIndexString(string indexName, string tableName)
         {
-            var sb = new StringBuilder("drop index if exists ")
-                .Append(QuoteForColumnName(indexName));
-
-            return sb.ToString();
+            return "drop index if exists " + QuoteForColumnName(indexName);
         }
 
         public override string QuoteForColumnName(string columnName)

--- a/src/YesSql.Provider.Sqlite/SqliteDialect.cs
+++ b/src/YesSql.Provider.Sqlite/SqliteDialect.cs
@@ -52,6 +52,8 @@ namespace YesSql.Provider.Sqlite
 
         public override string IdentitySelectString => "; select last_insert_rowid()";
 
+        public override bool SupportsTableNameAfterIndexName => false;
+
         public override string GetTypeName(DbType dbType, int? length, byte precision, byte scale)
         {
             if (ColumnTypes.TryGetValue(dbType, out string value))


### PR DESCRIPTION
Fixes https://github.com/sebastienros/yessql/issues/184

I've tested this on MS SQL and SQLite and works well.

Research says that MySQL supports `ON table_name` syntax when dropping indexes, but PostgreSql does not, so have coded accordingly.

May not actually need to use this feature for the issue I was trying to fix (change length of column), but as many database providers are involved and can behave differently , it seemed sensible to be able to drop the index, change the column length, and recreate the index