### PR TITLE
#189 change "id" to "Id" in DefaultIdGenerator.cs InitializeCollectio…

### DIFF
--- a/src/YesSql.Core/Services/DefaultIdGenerator.cs
+++ b/src/YesSql.Core/Services/DefaultIdGenerator.cs
@@ -57,7 +57,7 @@ namespace YesSql.Services
                 {
                     var tableName = String.IsNullOrEmpty(collection) ? "Document" : collection + "_" + "Document";
 
-                    var sql = "SELECT MAX(" + _dialect.QuoteForColumnName("id") + ") FROM " + _dialect.QuoteForTableName(_tablePrefix + tableName);
+                    var sql = "SELECT MAX(" + _dialect.QuoteForColumnName("Id") + ") FROM " + _dialect.QuoteForTableName(_tablePrefix + tableName);
 
                     var selectCommand = transaction.Connection.CreateCommand();
                     selectCommand.CommandText = sql;


### PR DESCRIPTION
fixes #189 

As the column name is hard coded to "Id", so I assume that the same is identical in all kind of database. I think it is safe to change to use "Id" in this PR.