### PR TITLE
MS SQL Add brackets around TOP value to provide support for parameters

### DIFF
--- a/src/YesSql.Provider.SqlServer/SqlServerDialect.cs
+++ b/src/YesSql.Provider.SqlServer/SqlServerDialect.cs
@@ -115,9 +115,9 @@ namespace YesSql.Provider.SqlServer
             }
             else if (limit != null)
             {
-                // Insert LIMIT clause after the select
+                // Insert LIMIT clause after the select with brackets for parameters
                 sqlBuilder.InsertSelector(" ");
-                sqlBuilder.InsertSelector(limit);
+                sqlBuilder.InsertSelector("(" + limit + ")");
                 sqlBuilder.InsertSelector("TOP ");
             }
         }


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/3986

Seemed easiest to always put the brackets around the `TOP value` as SQL Server seems happy if its `TOP (2)` or `TOP (@parameter)` but always fails with `TOP @parameter`

Will break the OC tests :)