### PR TITLE
Allow the use of non-supported orderby clauses 

### DIFF
--- a/src/YesSql.Abstractions/IQuery.cs
+++ b/src/YesSql.Abstractions/IQuery.cs
@@ -79,8 +79,12 @@ namespace YesSql
         IQuery<T, TIndex> WithParameter(string name, object value);
         IQuery<T, TIndex> Where(Expression<Func<TIndex, bool>> predicate);
         IQuery<T, TIndex> OrderBy(Expression<Func<TIndex, object>> keySelector);
+        IQuery<T, TIndex> OrderBy(string sql);
         IQuery<T, TIndex> OrderByDescending(Expression<Func<TIndex, object>> keySelector);
+        IQuery<T, TIndex> OrderByDescending(string sql);
         IQuery<T, TIndex> ThenBy(Expression<Func<TIndex, object>> keySelector);
+        IQuery<T, TIndex> ThenBy(string sql);
         IQuery<T, TIndex> ThenByDescending(Expression<Func<TIndex, object>> keySelector);
+        IQuery<T, TIndex> ThenByDescending(string sql);
     }
 }

--- a/src/YesSql.Core/Services/DefaultQuery.cs
+++ b/src/YesSql.Core/Services/DefaultQuery.cs
@@ -1232,9 +1232,21 @@ namespace YesSql.Services
                 return this;
             }
 
+            IQuery<T, TIndex> IQuery<T, TIndex>.OrderBy(string sql)
+            {
+                _query._queryState._sqlBuilder.OrderBy(sql);
+                return this;
+            }
+
             IQuery<T, TIndex> IQuery<T, TIndex>.ThenBy(Expression<Func<TIndex, object>> keySelector)
             {
                 _query.ThenBy(keySelector);
+                return this;
+            }
+
+            IQuery<T, TIndex> IQuery<T, TIndex>.ThenBy(string sql)
+            {
+                _query._queryState._sqlBuilder.ThenOrderBy(sql);
                 return this;
             }
 
@@ -1244,9 +1256,21 @@ namespace YesSql.Services
                 return this;
             }
 
+            IQuery<T, TIndex> IQuery<T, TIndex>.OrderByDescending(string sql)
+            {
+                _query._queryState._sqlBuilder.OrderByDescending(sql);
+                return this;
+            }
+
             IQuery<T, TIndex> IQuery<T, TIndex>.ThenByDescending(Expression<Func<TIndex, object>> keySelector)
             {
                 _query.ThenByDescending(keySelector);
+                return this;
+            }
+
+            IQuery<T, TIndex> IQuery<T, TIndex>.ThenByDescending(string sql)
+            {
+                _query._queryState._sqlBuilder.ThenOrderByDescending(sql);
                 return this;
             }
         }


### PR DESCRIPTION
Allow the use of non-supported orderby clauses insyead of limiting to just index columnnames; eg functions/case statesments, etc