### PR TITLE
Fix table syntax for postgresql version upgrade

### DIFF
--- a/src/YesSql.Core/Store.cs
+++ b/src/YesSql.Core/Store.cs
@@ -118,7 +118,7 @@ namespace YesSql
                     var selectBuilder = Dialect.CreateBuilder(Configuration.TablePrefix);
                     selectBuilder.Select();
                     selectBuilder.AddSelector("*");
-                    selectBuilder.From(Configuration.TablePrefix + documentTable);
+                    selectBuilder.Table(documentTable);
                     selectBuilder.Take("1");
 
                     selectCommand.CommandText = selectBuilder.ToSqlString();


### PR DESCRIPTION
The version upgrade fails on postgresql because `.From` doesn't take into account the case sensitivity of the table name (comes through as `document` where it needs to be `Document`)

`.Table` does take into account correctly, and also applies the table prefix, so under postgresql I can now see the version column being created when required.

Tested change does not affect sqlite or ms sql. Not tested under mysql.

Fixes Orchard Core issue https://github.com/OrchardCMS/OrchardCore/issues/4842