### PR TITLE
Upgrade dependencies

### DIFF
--- a/src/YesSql.Abstractions/YesSql.Abstractions.csproj
+++ b/src/YesSql.Abstractions/YesSql.Abstractions.csproj
@@ -6,7 +6,7 @@
         <VersionPrefix>2.0.0</VersionPrefix>
     </PropertyGroup>
     <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.1' ">
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />

--- a/src/YesSql.Core/YesSql.Core.csproj
+++ b/src/YesSql.Core/YesSql.Core.csproj
@@ -6,9 +6,9 @@
         <LangVersion>8.0</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Dapper.StrongName" Version="2.0.30" />
-        <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-        <PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
+        <PackageReference Include="Dapper.StrongName" Version="2.0.35" />
+        <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+        <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />

--- a/src/YesSql.Provider.MySql/YesSql.Provider.MySql.csproj
+++ b/src/YesSql.Provider.MySql/YesSql.Provider.MySql.csproj
@@ -5,7 +5,7 @@
         <VersionPrefix>1.0.0</VersionPrefix>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="MySqlConnector" Version="0.60.2" />
+        <PackageReference Include="MySqlConnector" Version="0.66.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\YesSql.Core\YesSql.Core.csproj" />

--- a/src/YesSql.Provider.PostgreSql/YesSql.Provider.PostgreSql.csproj
+++ b/src/YesSql.Provider.PostgreSql/YesSql.Provider.PostgreSql.csproj
@@ -8,6 +8,6 @@
         <ProjectReference Include="..\YesSql.Provider.Common\YesSql.Provider.Common.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Npgsql" Version="4.1.1" />
+        <PackageReference Include="Npgsql" Version="4.1.3.1" />
     </ItemGroup>
 </Project>

--- a/src/YesSql.Provider.SqlServer/YesSql.Provider.SqlServer.csproj
+++ b/src/YesSql.Provider.SqlServer/YesSql.Provider.SqlServer.csproj
@@ -8,6 +8,6 @@
         <ProjectReference Include="..\YesSql.Provider.Common\YesSql.Provider.Common.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Data.SqlClient" Version="1.0.19269.1" />
+        <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.3" />
     </ItemGroup>
 </Project>

--- a/src/YesSql.Provider.Sqlite/YesSql.Provider.Sqlite.csproj
+++ b/src/YesSql.Provider.Sqlite/YesSql.Provider.Sqlite.csproj
@@ -8,6 +8,6 @@
         <ProjectReference Include="..\YesSql.Provider.Common\YesSql.Provider.Common.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Data.Sqlite" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.4" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
General upgrade to dependencies, but specifically was targeting `Microsoft.Data.SqlClient" Version="1.1.3"` as there have been rumours of deadlock / timeout issues introduced by a regression, and fixed in this later release.

Refer : https://github.com/dotnet/SqlClient/issues/262#issuecomment-587518102