### PR TITLE
Fix that Indexes and ScopedIndexes are null upon Store construction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ project.lock.json
 .vs/
 .build/
 .testPublish/ 
+.idea

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,7 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+
 <configuration>
-  <packageSources>
-    <add key="AspNetCore" value="https://dotnet.myget.org/F/aspnetcore-master/api/v3/index.json" />
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
+    <packageSources>
+        <clear />
+        <add key="AspNetCore" value="https://dotnet.myget.org/F/aspnetcore-master/api/v3/index.json" />
+        <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    </packageSources>
 </configuration>

--- a/samples/YesSql.Samples.Web/Startup.cs
+++ b/samples/YesSql.Samples.Web/Startup.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using YesSql.Provider.SqlServer;
 
 namespace YesSql.Samples.Web
@@ -12,10 +13,10 @@ namespace YesSql.Samples.Web
             services.AddDbProvider(config =>
                 config.UseSqlServer("Server=.;Database=YesSqlDb;Integrated Security=True"));
 
-            services.AddMvc();
+            services.AddMvc(options => options.EnableEndpointRouting = false);
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {

--- a/src/YesSql.Core/Store.cs
+++ b/src/YesSql.Core/Store.cs
@@ -56,11 +56,17 @@ namespace YesSql
             // Add Type Handlers here
         }
 
+        private Store()
+        {
+            Indexes = new List<IIndexProvider>();
+            ScopedIndexes = new List<Type>();
+        }
+
         /// <summary>
         /// Initializes a <see cref="Store"/> instance and its new <see cref="Configuration"/>.
         /// </summary>
         /// <param name="config">An action to execute on the <see cref="Configuration"/> of the new <see cref="Store"/> instance.</param>
-        internal Store(Action<IConfiguration> config)
+        internal Store(Action<IConfiguration> config) : this()
         {
             Configuration = new Configuration();
             config?.Invoke(Configuration);
@@ -70,7 +76,7 @@ namespace YesSql
         /// Initializes a <see cref="Store"/> instance using a specific <see cref="Configuration"/> instance.
         /// </summary>
         /// <param name="configuration">The <see cref="Configuration"/> instance to use.</param>
-        internal Store(IConfiguration configuration)
+        internal Store(IConfiguration configuration) : this()
         {
             Configuration = configuration;
         }
@@ -78,8 +84,6 @@ namespace YesSql
         public async Task InitializeAsync()
         {
             IndexCommand.ResetQueryCache();
-            Indexes = new List<IIndexProvider>();
-            ScopedIndexes = new List<Type>();
             ValidateConfiguration();
 
             _sessionPool = new ObjectPool<Session>(MakeSession, Configuration.SessionPoolSize);


### PR DESCRIPTION
When instantiating a new `Store`, it is impossible to add index providers to `Indexes` until after `InitializeAsync` is called.
This PR fixes that by making sure `Indexes` (and `ScopedIndexes`) is initialized to an empty list as soon as the `Store` is instantiated (rather than waiting to do so during `InitializeAsync`.