### PR TITLE
Check concurrency issue

### DIFF
--- a/src/YesSql.Core/Session.cs
+++ b/src/YesSql.Core/Session.cs
@@ -370,7 +370,7 @@ namespace YesSql
                 {
                     oldDoc.Version--;
 
-                    // restore the old version to the object
+                    // revert the version update
                     if (versionAccessor != null)
                     {
                         versionAccessor.Set(entity, (int)oldDoc.Version);


### PR DESCRIPTION
Related to https://github.com/OrchardCMS/OrchardCore/issues/7449 and https://github.com/OrchardCMS/OrchardCore/issues/7545

**Repro**

- Save a given entity with `checkConcurrency` to true
- Do a first session query non related to the above entity => `FlushAsync()`
- Do at least a 2nd session query => `FlushAsync()`
- ...
- Save again the same entity with `checkConcurrency` to true
- `CommitAsync()`

On the first `FlushAsync()` a `SaveEntityAsync()` is done that enlists a `CreateDocumentCommand()` that is then executed, finally the entity is added to `state.Tracked` and removed from `state.Saved`. On the second `FlushAsync()`, because the entity is in `state.Tracked`, `UpdateEntityAsync()` is called where, because of the `checkConcurrency`, **the version is incremented but, because the entity is tracked and its content has not changed yet, the related `UpdateDocumentCommand` is not enlisted, so not executed through the current flush**.

Then when the entity is saved again, it is removed from `state.Tracked` and added to `state.Updated`, so when the session is committed, through the final flush that recalls `UpdateEntityAsync()`, **the version is incremented again** and, because the entity is no more tracked (and its content may have been updated), an `UpdateDocumentCommand` is enlisted and then executed. **So the document version is incremented twice but only one `UpdateDocumentCommand` is executed, so there is a version missmatch resulting in a false `ConcurrencyException`**

So here,  if the entity is tracked and its content has not changed yet, i revert the document version update.

**Update**:

I built YesSql locally and made packages in a local feed, so i could try my YesSql updates, I can confirm that it fixes the related OC issue. Note: To be able to build OC in this context i needed to do some adaptations as currently we don't reference the last dev of YesSql. E.g. `StoreFactory.CreateAsync()` replaced by `StoreFactory.CreateAndInitializeAsync()`.

**Update**: I found a temporary fix on OC side, defining a `Version` property in our `Document` base class prevents a version missmatch, this because the version of the tracked object is also incremented, so its serialized content becomes different and then the related `UpdateDocumentCommand` is enlisted.