### PR TITLE
SqlServer 2008 Dialect fixing pagination with nested query

### DIFF
--- a/src/YesSql.Abstractions/ISqlBuilder.cs
+++ b/src/YesSql.Abstractions/ISqlBuilder.cs
@@ -18,11 +18,16 @@ namespace YesSql
         void OrderBy(string orderBy);
         void OrderByDescending(string orderBy);
         void OrderByRandom();
+        string GetOrder();
         void Select();
         void Selector(string selector);
         void Selector(string table, string column);
         void AddSelector(string select);
         void InsertSelector(string select);
+        void ParentSelector(string selector);
+        void ParentSelector(string table, string column);
+        void AddParentSelector(string select);
+        void InsertParentSelector(string select);
         void Distinct();
         bool HasPaging { get; }
         void Skip(string skip);
@@ -39,6 +44,8 @@ namespace YesSql
         string ToSqlString();
         void WhereAnd(string clause);
         void WhereOr(string clause);
+        void ParentWhereAnd(string where);        
+        void ParentWhereOr(string where);
         ISqlBuilder Clone();
     }
 }

--- a/src/YesSql.Provider.Common/BaseDialect.cs
+++ b/src/YesSql.Provider.Common/BaseDialect.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Globalization;
+using System.Linq;
 using System.Text;
 using YesSql.Sql;
 
@@ -207,9 +208,10 @@ namespace YesSql.Provider
             foreach (var o in orderBy)
             {
                 var trimmed = o.Trim();
+                var table = trimmed.Split('.')[0];
 
                 // Each order segment can be a field name, or a punctuation, so we filter out the punctuations 
-                if (trimmed != "," && trimmed != "DESC" && trimmed != "ASC" && !select.Contains(o))
+                if (trimmed != "," && trimmed != "DESC" && trimmed != "ASC" && !select.Contains(o) && !select.Any(s=>s==$"{table}.*"))
                 {
                     select.Add(",");
                     select.Add(o);

--- a/src/YesSql.Provider.SqlServer/SqlServer2008Dialect .cs
+++ b/src/YesSql.Provider.SqlServer/SqlServer2008Dialect .cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Text;
+using YesSql.Sql;
+
+namespace YesSql.Provider.SqlServer
+{
+    public class SqlServer2008Dialect : SqlServerDialect
+    {
+        private static Dictionary<DbType, string> ColumnTypes = new Dictionary<DbType, string>
+        {
+            {DbType.Guid, "UNIQUEIDENTIFIER"},
+            {DbType.Binary, "VARBINARY(8000)"},
+            {DbType.Time, "DATETIME"},
+            {DbType.Date, "DATETIME"},
+            {DbType.DateTime, "DATETIME" },
+            {DbType.DateTime2, "DATETIME2" },
+            {DbType.DateTimeOffset, "datetimeoffset" },
+            {DbType.Boolean, "BIT"},
+            {DbType.Byte, "TINYINT"},
+            {DbType.Currency, "MONEY"},
+            {DbType.Decimal, "DECIMAL(19,5)"},
+            {DbType.Double, "FLOAT(53)"},
+            {DbType.Int16, "SMALLINT"},
+            {DbType.UInt16, "SMALLINT"},
+            {DbType.Int32, "INT"},
+            {DbType.UInt32, "BIGINT"},
+            {DbType.Int64, "BIGINT"},
+            {DbType.UInt64, "NUMERIC(20)"},
+            {DbType.Single, "REAL"},
+            {DbType.AnsiStringFixedLength, "CHAR(255)"},
+            {DbType.AnsiString, "VARCHAR(255)"},
+            {DbType.StringFixedLength, "NCHAR(255)"},
+            {DbType.String, "NVARCHAR(255)"},
+        };
+
+        public SqlServer2008Dialect() : base()
+        {
+            // These are necessary for backward compatibility with SQL Server 2008 
+            Methods.Add("day", new TemplateFunction("datepart(day, {0})"));
+            Methods.Add("month", new TemplateFunction("datepart(month, {0})"));
+            Methods.Add("year", new TemplateFunction("datepart(year, {0})"));
+        }
+
+        public override void Page(ISqlBuilder sqlBuilder, string offset, string limit)
+        {
+            if (offset != null)
+            {
+                var offsetVal = long.Parse(offset);
+                sqlBuilder.InsertParentSelector("*");
+                var sb = new StringBuilder();
+                sb.Append(", ROW_NUMBER()");
+                var currentOrder = sqlBuilder.GetOrder();
+                if (currentOrder != "")
+                {
+                    sb.Append(" OVER( ORDER BY ");
+                    sb.Append(currentOrder);
+                    sb.Append(")");
+                }
+                sb.Append(" AS Seq");
+                sqlBuilder.AddSelector(sb.ToString());
+                if (limit != null)
+                {
+                    sqlBuilder.ParentWhereAnd($"Seq BETWEEN {offsetVal + 1} AND {long.Parse(limit) + offsetVal}");
+                }
+                else
+                {
+                    sqlBuilder.ParentWhereAnd($"Seq >= {offsetVal + 1}");
+                }
+            }
+            else if (limit != null)
+            {
+                // Insert LIMIT clause after the select with brackets for parameters
+                sqlBuilder.InsertSelector(" ");
+                sqlBuilder.InsertSelector("(" + limit + ")");
+                sqlBuilder.InsertSelector("TOP ");
+            }
+        }
+
+    }
+}

--- a/src/YesSql.Provider.SqlServer/SqlServerDbProviderOptionsExtensions.cs
+++ b/src/YesSql.Provider.SqlServer/SqlServerDbProviderOptionsExtensions.cs
@@ -13,10 +13,31 @@ namespace YesSql.Provider.SqlServer
             return UseSqlServer(configuration, connectionString, IsolationLevel.ReadUncommitted);
         }
 
+        public static IConfiguration UseSqlServer2008(
+            this IConfiguration configuration,
+            string connectionString)
+        {
+            return UseSqlServer2008(configuration, connectionString, IsolationLevel.ReadUncommitted);
+        }
         public static IConfiguration UseSqlServer(
             this IConfiguration configuration,
             string connectionString,
             IsolationLevel isolationLevel)
+        {
+            return UseSqlServer(configuration, connectionString, isolationLevel, new SqlServerDialect());
+        }
+        public static IConfiguration UseSqlServer2008(
+            this IConfiguration configuration,
+            string connectionString,
+            IsolationLevel isolationLevel)
+        {
+            return UseSqlServer(configuration, connectionString, isolationLevel, new SqlServer2008Dialect());
+        }
+        private static IConfiguration UseSqlServer(
+        this IConfiguration configuration,
+        string connectionString,
+        IsolationLevel isolationLevel,
+        ISqlDialect sqlDialect)
         {
             if (configuration == null)
             {
@@ -28,7 +49,7 @@ namespace YesSql.Provider.SqlServer
                 throw new ArgumentException(nameof(connectionString));
             }
 
-            configuration.SqlDialect = new SqlServerDialect();
+            configuration.SqlDialect = sqlDialect;
             configuration.CommandInterpreter = new SqlServerCommandInterpreter(configuration.SqlDialect);
             configuration.ConnectionFactory = new DbConnectionFactory<SqlConnection>(connectionString);
             configuration.IsolationLevel = isolationLevel;

--- a/test/YesSql.Tests/SqlServer2008Tests.cs
+++ b/test/YesSql.Tests/SqlServer2008Tests.cs
@@ -1,0 +1,27 @@
+using System;
+using Xunit.Abstractions;
+using YesSql.Provider.SqlServer;
+
+namespace YesSql.Tests
+{
+    public class SqlServer2008Tests : SqlServerTests
+    {
+        public SqlServer2008Tests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override IConfiguration CreateConfiguration()
+        {
+            var connectionString =
+            Environment.GetEnvironmentVariable("SQLSERVER_2008_CONNECTION_STRING")
+            ?? @"Data Source=.;Initial Catalog=tempdb;Integrated Security=True"
+            ;
+
+            return new Configuration()
+                .UseSqlServer2008(connectionString)
+                .SetTablePrefix(TablePrefix)
+                .UseBlockIdGenerator()
+                ;
+        }
+    }
+}


### PR DESCRIPTION
Just in case it is useful to merge or to combine with this other PR https://github.com/sebastienros/yessql/pull/64 . Here is my proposal for fixing Sql Server 2008 pagination. 
It produces nested queries for this purpose cause as far as I know this is the only way of having pagination with this sql server version.
This is the kind of query it is produces:

SELECT * FROM (SELECT DISTINCT [Document].*, ROW_NUMBER() OVER( ORDER BY [UserIndex].[NormalizedUserName]) AS Seq,[UserIndex].[NormalizedUserName] FROM [Document] INNER JOIN [UserIndex] ON [UserIndex].[DocumentId] = [Document].[Id] ) yessqlQuery WHERE Seq BETWEEN 1 AND 10

I've checked pagination tests run ok with this dialect and Sql Server 2008
However other tests don't pass.

The failing tests are a group related with index lenght as @deanmarcussen pointed here https://github.com/sebastienros/yessql/pull/64#issuecomment-734159110

````
ShouldCreateAndIndexPropertyWithMaximumKeyLengths Failed	7,4 sec		Microsoft.Data.SqlClient.SqlException : Operation failed. The index entry of length 1535 bytes for the index 'IDX_Property' exceeds the maximum length of 900 bytes.
````
````
ShouldIndexPropertyKey Failed	7,2 sec		Microsoft.Data.SqlClient.SqlException : Operation failed. The index entry of length 1700 bytes for the index 'IDX_Property' exceeds the maximum length of 900 bytes.
````
````
ShouldIndexPropertyKeys Failed	7 sec		Microsoft.Data.SqlClient.SqlException : Operation failed. The index entry of length 1700 bytes for the index 'IDX_Property' exceeds the maximum length of 900 bytes.
````
````
ShouldIndexPropertyKeysWithBits Failed	9,6 sec		Microsoft.Data.SqlClient.SqlException : Operation failed. The index entry of length 1699 bytes for the index 'IDX_Property' exceeds the maximum length of 900 bytes.
````

IMO, this kind of errors is not a problem that yessql should control, it is a problem for those who use YesSql with a version of a db with a smaller maximum leght for the index. So, they will have to limit the lenght of the indexes defined at their code if they want to support versions with a smaller maximum leght. For example maybe Orchard Core should be sure to don't use indexes greater that the minimum of SqlServer 2008 on its code. Developers will be free of using the size of the index they want only on their custom modules.

Another group of test errors happens on tests that are sensible to the delay in communication with db:
```
 ShouldGenerateIdsConcurrently(collection: "")
   Source: CoreTests.cs line 3984
   Duration: 17,6 sec  Message: 
    lastId: 745
    Expected: True
    Actual:   False
```
```
 ShouldGenerateIdsConcurrently(collection: "Collection1")
   Source: CoreTests.cs line 3984
   Duration: 17,6 sec

  Message: 
    lastId: 825
    Expected: True
    Actual:   False
```
Reason is I'm using an sql server 2008 hosted in a cheap virtual machine at the cloud for testing from my local pc, so I wouldn't worry of those fails.

Finally the last group of errors are those caused by an error that exist in dev branch which makes failing these tests also for SQL Server 2019 with original SQLServer dialect, because the wrong connection string is used for them. As soon as they are fixed for original dialect I expect it will work for SQLServer2008 dialec:
```
 ShouldGenerateIdsWithConcurrentStores(collection: "")
   Source: SqlServerTests.cs line 97
   Duration: 36 sec

  Message: 
    Microsoft.Data.SqlClient.SqlException : A network-related or instance-specific error occurred while establishing a connection to SQL Server. The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server is configured to allow remote connections. (provider: Named Pipes Provider, error: 40 - Could not open a connection to SQL Server)
````
````
 ShouldGenerateIdsWithConcurrentStores(collection: "Collection1")
   Source: SqlServerTests.cs line 97
   Duration: 34,9 sec

  Message: 
    Microsoft.Data.SqlClient.SqlException : A network-related or instance-specific error occurred while establishing a connection to SQL Server. The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server is configured to allow remote connections. (provider: Named Pipes Provider, error: 40 - Could not open a connection to SQL Server)
````