### PR TITLE
Fix tests still using old connection string 

### DIFF
--- a/test/YesSql.Tests/SqlServer2017Tests.cs
+++ b/test/YesSql.Tests/SqlServer2017Tests.cs
@@ -6,19 +6,19 @@ namespace YesSql.Tests
 {
     public class SqlServer2017Tests : SqlServerTests
     {
+        public override string ConnectionString 
+            =>  Environment.GetEnvironmentVariable("SQLSERVER_2017_CONNECTION_STRING") 
+                ?? @"Data Source=.;Initial Catalog=tempdb;Integrated Security=True"
+                ;
+
         public SqlServer2017Tests(ITestOutputHelper output) : base(output)
         {
         }
 
         protected override IConfiguration CreateConfiguration()
         {
-            var connectionString = 
-                Environment.GetEnvironmentVariable("SQLSERVER_2017_CONNECTION_STRING") 
-                ?? @"Data Source=.;Initial Catalog=tempdb;Integrated Security=True"
-                ;
-
             return new Configuration()
-                .UseSqlServer(connectionString)
+                .UseSqlServer(ConnectionString)
                 .SetTablePrefix(TablePrefix)
                 .UseBlockIdGenerator()
                 ;

--- a/test/YesSql.Tests/SqlServer2019Tests.cs
+++ b/test/YesSql.Tests/SqlServer2019Tests.cs
@@ -6,19 +6,20 @@ namespace YesSql.Tests
 {
     public class SqlServer2019Tests : SqlServerTests
     {
+
+        public override string ConnectionString 
+            =>  Environment.GetEnvironmentVariable("SQLSERVER_2019_CONNECTION_STRING") 
+                ?? @"Data Source=.;Initial Catalog=tempdb;Integrated Security=True"
+                ;
+
         public SqlServer2019Tests(ITestOutputHelper output) : base(output)
         {
         }
 
         protected override IConfiguration CreateConfiguration()
         {
-            var connectionString = 
-                Environment.GetEnvironmentVariable("SQLSERVER_2019_CONNECTION_STRING") 
-                ?? @"Data Source=.;Initial Catalog=tempdb;Integrated Security=True"
-                ;
-
             return new Configuration()
-                .UseSqlServer(connectionString)
+                .UseSqlServer(ConnectionString)
                 .SetTablePrefix(TablePrefix)
                 .UseBlockIdGenerator()
                 ;

--- a/test/YesSql.Tests/SqlServerTests.cs
+++ b/test/YesSql.Tests/SqlServerTests.cs
@@ -15,8 +15,8 @@ namespace YesSql.Tests
 {
     public abstract class SqlServerTests : CoreTests
     {
-        public static string ConnectionString => Environment.GetEnvironmentVariable("SQLSERVER_CONNECTION_STRING") ?? @"Data Source=.;Initial Catalog=tempdb;Integrated Security=True";
-
+        public abstract string ConnectionString { get; }
+        
         public SqlServerTests(ITestOutputHelper output) : base(output)
         {
         }


### PR DESCRIPTION
Fixes a couple of tests - `ShouldSeedExistingIds` +2, that were still looking at the old environment variables for sql server.

