### PR TITLE
Reduce max commands to 2098

### DIFF
--- a/src/YesSql.Provider.SqlServer/SqlServerDialect.cs
+++ b/src/YesSql.Provider.SqlServer/SqlServerDialect.cs
@@ -243,6 +243,6 @@ namespace YesSql.Provider.SqlServer
 
         public override bool SupportsIfExistsBeforeTableName => true;
 
-        public override int MaxParametersPerCommand => 2099;
+        public override int MaxParametersPerCommand => 2098;
     }
 }

--- a/test/YesSql.Tests/CoreTests.cs
+++ b/test/YesSql.Tests/CoreTests.cs
@@ -5190,7 +5190,14 @@ namespace YesSql.Tests
 
             using (var session = _store.CreateSession())
             {
-                Assert.Equal(1000, await session.QueryIndex<PersonByAge>().CountAsync());
+                var persons = (await session.Query<Person>().ListAsync());
+                Assert.Equal(1000, persons.Count());
+                // This will produce a query that batches at 2099 parameters which will fail.
+                // When reduced to a maximum to 2098, i.e. stopping the batch before 2099, it will pass.
+                foreach (var person in persons)
+                {   
+                    session.Save(person);
+                }              
             }
         }
     }


### PR DESCRIPTION
This first run will fail.

This query, propitiously, produces a batch of 2099 exactly, on its first batch.

And sql server will drop it, even though it doesn't exceed 2100. 
I wonder if it is adding an extra param or two, from the `SCOPE_IDENTITY` but not sure.

It's not a perfect test, because if the model or index changed, and it wasn't producing a batch of 2099, it would still pass,  (some experimentation with other models in here as well changed the batched parameter count to 2097, or 2096, and it would then all pass).

Regardless, and after validating with some other models as well, 2098 seems to be the magic number.

I'll let this test run, so you see can see it fail first, before tweaking the number.

