### PR TITLE
Fix remove index for < SQL Server 2016

### DIFF
--- a/src/YesSql.Provider.SqlServer/SqlServerDialect.cs
+++ b/src/YesSql.Provider.SqlServer/SqlServerDialect.cs
@@ -196,7 +196,9 @@ namespace YesSql.Provider.SqlServer
 
         public override string GetDropIndexString(string indexName, string tableName)
         {
-            return "drop index if exists " + QuoteForColumnName(indexName) + " on " + QuoteForTableName(tableName);
+            var command = "IF EXISTS (SELECT * FROM sys.indexes WHERE NAME = N'" + QuoteForColumnName(indexName) +  "')"
+                        + "DROP INDEX" + QuoteForColumnName(indexName) + " ON " + QuoteForTableName(tableName);
+            return command;
         }
 
         public override string QuoteForColumnName(string columnName)


### PR DESCRIPTION
Fixes #346
Use database sys.indexes table to define if the index exist before removing it.

See : https://www.mssqltips.com/sqlservertip/4402/new-drop-if-exists-syntax-in-sql-server-2016/