### PR TITLE
Added SessionReadOnly

### DIFF
--- a/src/YesSql.Abstractions/ISession.cs
+++ b/src/YesSql.Abstractions/ISession.cs
@@ -10,7 +10,7 @@ namespace YesSql
     /// <summary>
     /// Represents a connection to the document store.
     /// </summary>
-    public interface ISession : IDisposable, IAsyncDisposable
+    public interface ISession : ISessionReadOnly, IDisposable, IAsyncDisposable
     {
         /// <summary>
         /// Saves a new or existing object to the store, and updates
@@ -51,27 +51,6 @@ namespace YesSql
         void Detach(object item, string collection = null);
 
         /// <summary>
-        /// Loads objects by id.
-        /// </summary>
-        /// <returns>A collection of objects in the same order they were defined.</returns>
-        Task<IEnumerable<T>> GetAsync<T>(int[] ids, string collection = null) where T : class;
-
-        /// <summary>
-        /// Creates a new <see cref="IQuery"/> object.
-        /// </summary>
-        IQuery Query(string collection = null);
-
-        /// <summary>
-        /// Executes a compiled query.
-        /// </summary>
-        /// <remarks>
-        /// A compiled query is an instance of a class implementing <see cref="ICompiledQuery{T}" />.
-        /// Compiled queries allow YesSql to cache the SQL statement that would be otherwise generated
-        /// on each invocation of the LINQ query. 
-        /// </remarks>
-        IQuery<T> ExecuteQuery<T>(ICompiledQuery<T> compiledQuery, string collection = null) where T : class;
-
-        /// <summary>
         /// Cancels any pending commands.
         /// </summary>
         void Cancel();
@@ -107,24 +86,10 @@ namespace YesSql
         /// <param name="collection">The name of the collection to store the object in.</param>
         /// <returns>The <see cref="ISession"/> instance.</returns>
         ISession RegisterIndexes(IIndexProvider[] indexProviders, string collection = null);
-
-        /// <summary>
-        /// Gets the <see cref="Store" /> instance that created this session. 
-        /// </summary>
-        IStore Store { get; }
     }
 
     public static class SessionExtensions
     {
-        /// <summary>
-        /// Loads an object by its id.
-        /// </summary>
-        /// <returns>The object or <c>null</c>.</returns>
-        public async static Task<T> GetAsync<T>(this ISession session, int id, string collection = null) where T : class
-        {
-            return (await session.GetAsync<T>(new[] { id }, collection)).FirstOrDefault();
-        }
-
         /// <summary>
         /// Imports an object in the local identity map.
         /// </summary>

--- a/src/YesSql.Abstractions/ISessionReadOnly.cs
+++ b/src/YesSql.Abstractions/ISessionReadOnly.cs
@@ -50,9 +50,9 @@ namespace YesSql
         /// Loads an object by its id.
         /// </summary>
         /// <returns>The object or <c>null</c>.</returns>
-        public async static Task<T> GetAsync<T>(this ISession session, int id, string collection = null) where T : class
+        public async static Task<T> GetAsync<T>(this ISessionReadOnly sessionReadOnly, int id, string collection = null) where T : class
         {
-            return (await session.GetAsync<T>(new[] { id }, collection)).FirstOrDefault();
+            return (await sessionReadOnly.GetAsync<T>(new[] { id }, collection)).FirstOrDefault();
         }
     }
 }

--- a/src/YesSql.Abstractions/ISessionReadOnly.cs
+++ b/src/YesSql.Abstractions/ISessionReadOnly.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using System.Threading.Tasks;
+using YesSql.Indexes;
+
+namespace YesSql
+{
+    /// <summary>
+    /// Represents a connection to the document store.
+    /// </summary>
+    public interface ISessionReadOnly : IDisposable
+    {
+        /// <summary>
+        /// Loads objects by id.
+        /// </summary>
+        /// <returns>A collection of objects in the same order they were defined.</returns>
+        Task<IEnumerable<T>> GetAsync<T>(int[] ids, string collection = null) where T : class;
+
+        /// <summary>
+        /// Creates a new <see cref="IQuery"/> object.
+        /// </summary>
+        IQuery Query(string collection = null);
+
+        /// <summary>
+        /// Executes a compiled query.
+        /// </summary>
+        /// <remarks>
+        /// A compiled query is an instance of a class implementing <see cref="ICompiledQuery{T}" />.
+        /// Compiled queries allow YesSql to cache the SQL statement that would be otherwise generated
+        /// on each invocation of the LINQ query. 
+        /// </remarks>
+        IQuery<T> ExecuteQuery<T>(ICompiledQuery<T> compiledQuery, string collection = null) where T : class;
+
+
+        /// <summary>
+        /// Gets the <see cref="Store" /> instance that created this session. 
+        /// </summary>
+        IStore Store { get; }
+    }
+    /// <summary>
+    /// Represents a connection to the document store.
+    /// </summary>
+    
+
+    public static class SessionReadOnlyExtensions
+    {
+        /// <summary>
+        /// Loads an object by its id.
+        /// </summary>
+        /// <returns>The object or <c>null</c>.</returns>
+        public async static Task<T> GetAsync<T>(this ISession session, int id, string collection = null) where T : class
+        {
+            return (await session.GetAsync<T>(new[] { id }, collection)).FirstOrDefault();
+        }
+    }
+}

--- a/src/YesSql.Abstractions/IStore.cs
+++ b/src/YesSql.Abstractions/IStore.cs
@@ -58,5 +58,14 @@ namespace YesSql
         {
             return store.CreateSession(store.Configuration.IsolationLevel);
         }
+
+        /// <summary>
+        /// Creates a new <see cref="ISession"/> to communicate with the <see cref="IStore"/> with
+        /// the default <see cref="IsolationLevel"/>.
+        /// </summary>
+        public static ISessionReadOnly CreateSessionReadOnly(this IStore store)
+        {
+            return store.CreateSession(IsolationLevel.Unspecified);
+        }
     }
 }

--- a/src/YesSql.Abstractions/QueryExtensions.cs
+++ b/src/YesSql.Abstractions/QueryExtensions.cs
@@ -9,65 +9,65 @@ namespace YesSql
         /// <summary>
         /// Creates a query on object of a type.
         /// </summary>
-        public static IQuery<T> Query<T>(this ISession session, string collection = null) where T : class
+        public static IQuery<T> Query<T>(this ISessionReadOnly sessionReadOnly, string collection = null) where T : class
         {
-            return session.Query(collection).For<T>();
+            return sessionReadOnly.Query(collection).For<T>();
         }
 
         /// <summary>
         /// Creates a query on an index.
         /// </summary>
-        public static IQueryIndex<TIndex> QueryIndex<TIndex>(this ISession session, string collection = null) where TIndex : class, IIndex
+        public static IQueryIndex<TIndex> QueryIndex<TIndex>(this ISessionReadOnly sessionReadOnly, string collection = null) where TIndex : class, IIndex
         {
-            return session.Query(collection).ForIndex<TIndex>();
+            return sessionReadOnly.Query(collection).ForIndex<TIndex>();
         }
 
         /// <summary>
         /// Creates a query on an index, with a predicate.
         /// </summary>
-        public static IQueryIndex<TIndex> QueryIndex<TIndex>(this ISession session, Expression<Func<TIndex, bool>> predicate, string collection = null) where TIndex : class, IIndex
+        public static IQueryIndex<TIndex> QueryIndex<TIndex>(this ISessionReadOnly sessionReadOnly, Expression<Func<TIndex, bool>> predicate, string collection = null) where TIndex : class, IIndex
         {
-            return session.Query(collection).ForIndex<TIndex>().Where(predicate);
+            return sessionReadOnly.Query(collection).ForIndex<TIndex>().Where(predicate);
         }
 
         /// <summary>
         /// Creates a query for a type, using an index.
         /// </summary>
-        public static IQuery<T, TIndex> Query<T, TIndex>(this ISession session, bool filterType = false, string collection = null)
+        public static IQuery<T, TIndex> Query<T, TIndex>(this ISessionReadOnly sessionReadOnly, bool filterType = false, string collection = null)
             where T : class
             where TIndex : class, IIndex
         {
-            return session.Query(collection).For<T>(filterType).With<TIndex>();
+            return sessionReadOnly.Query(collection).For<T>(filterType).With<TIndex>();
         }
 
         /// <summary>
         /// Creates a query for a type, using an index.
         /// </summary>
-        public static IQuery<T, TIndex> Query<T, TIndex>(this ISession session, string collection)
+        public static IQuery<T, TIndex> Query<T, TIndex>(this ISessionReadOnly sessionReadOnly, string collection)
             where T : class
             where TIndex : class, IIndex
         {
-            return session.Query<T, TIndex>(false, collection);
+            return sessionReadOnly.Query<T, TIndex>(false, collection);
         }
 
         /// <summary>
         /// Creates a query for a type, using an index.
         /// </summary>
-        public static IQuery<T, TIndex> Query<T, TIndex>(this ISession session, Expression<Func<TIndex, bool>> predicate, bool filterType = false, string collection = null)
+        public static IQuery<T, TIndex> Query<T, TIndex>(this ISessionReadOnly sessionReadOnly, Expression<Func<TIndex, bool>> predicate, bool filterType = false, string collection = null)
             where T : class
             where TIndex : class, IIndex
         {
-            return session.Query(collection).For<T>(filterType).With<TIndex>(predicate);
+            return sessionReadOnly.Query(collection).For<T>(filterType).With<TIndex>(predicate);
         }
 
         /// <summary>
         /// Creates a query for a type, using an index.
         /// </summary>
-        public static IQuery<T, TIndex> Query<T, TIndex>(this ISession session, Expression<Func<TIndex, bool>> predicate, string collection)
+        public static IQuery<T, TIndex> Query<T, TIndex>(this ISessionReadOnly sessionReadOnly, Expression<Func<TIndex, bool>> predicate, string collection)
             where T : class
             where TIndex : class, IIndex
         {
-            return session.Query<T, TIndex>(predicate, false, collection);
+            return sessionReadOnly.Query<T, TIndex>(predicate, false, collection);
         }
     }
 }

--- a/src/YesSql.Core/Services/DefaultQuery.cs
+++ b/src/YesSql.Core/Services/DefaultQuery.cs
@@ -1005,7 +1005,8 @@ namespace YesSql.Services
                     var localTransaction = (DbTransaction)args[3];
 
                     localSession._store.Configuration.Logger.LogDebug(localSql);
-                    return localTransaction.Connection.ExecuteScalarAsync<int>(localSql, localParameters, localTransaction);
+                    var connection = localTransaction?.Connection ?? localSession.GetConnection();
+                    return connection.ExecuteScalarAsync<int>(localSql, localParameters, localTransaction);
                 }, 
                 _session, sql, parameters, transaction);
             }
@@ -1107,7 +1108,8 @@ namespace YesSql.Services
                             var localTransaction = (DbTransaction)args[2];
 
                             localQuery._session._store.Configuration.Logger.LogDebug(localSql);
-                            return localTransaction.Connection.QueryAsync<T>(localSql, localQuery._queryState._sqlBuilder.Parameters, localTransaction);
+                            var connection = localTransaction?.Connection ?? _query._session.GetConnection();
+                            return connection.QueryAsync<T>(localSql, localQuery._queryState._sqlBuilder.Parameters, localTransaction);
                         },
                         _query,
                         sql,
@@ -1126,7 +1128,8 @@ namespace YesSql.Services
                             var localTransaction = (DbTransaction)args[2];
 
                             localQuery._session._store.Configuration.Logger.LogDebug(localSql);
-                            return localTransaction.Connection.QueryAsync<Document>(localSql, localQuery._queryState._sqlBuilder.Parameters, localTransaction);
+                            var connection = localTransaction?.Connection ?? _query._session.GetConnection();
+                            return connection.QueryAsync<Document>(localSql, localQuery._queryState._sqlBuilder.Parameters, localTransaction);
                         }, 
                         _query,
                         sql,
@@ -1202,7 +1205,8 @@ namespace YesSql.Services
                             var localTransaction = (DbTransaction)args[2];
 
                             localQuery._session._store.Configuration.Logger.LogDebug(localSql);
-                            return localTransaction.Connection.QueryAsync<T>(localSql, localQuery._queryState._sqlBuilder.Parameters, localTransaction);
+                            var connection = localTransaction?.Connection ?? _query._session.GetConnection();
+                            return connection.QueryAsync<T>(localSql, localQuery._queryState._sqlBuilder.Parameters, localTransaction);
                         },
                         _query,
                         sql,
@@ -1228,7 +1232,8 @@ namespace YesSql.Services
                             var localTransaction = (DbTransaction)args[2];
 
                             localQuery._session._store.Configuration.Logger.LogDebug(localSql);
-                            return localTransaction.Connection.QueryAsync<Document>(localSql, localQuery._queryState._sqlBuilder.Parameters, localTransaction);
+                            var connection = localTransaction?.Connection ?? _query._session.GetConnection();
+                            return connection.QueryAsync<Document>(localSql, localQuery._queryState._sqlBuilder.Parameters, localTransaction);
                         },
                         _query,
                         sql,

--- a/test/YesSql.Tests/CoreTests.cs
+++ b/test/YesSql.Tests/CoreTests.cs
@@ -5259,27 +5259,6 @@ namespace YesSql.Tests
                 Firstname = "",
                 Version = 0
             };
-
-            using (var sessionOnlyForRead = _store.CreateSession())
-            {
-                var person = await sessionOnlyForRead.Query<Person>().FirstOrDefaultAsync();
-                Assert.Equal("Bill", (string)person.Firstname);
-
-                try
-                {
-                    using (var sessionForWrite = _store.CreateSession())
-                    {
-                        var personForWrite = await sessionForWrite.Query<Person>().FirstOrDefaultAsync();
-                        personForWrite.Firstname = "Jim";
-                        sessionForWrite.Save(personForWrite);
-                        sessionForWrite.CommitAsync();
-                    }
-                }
-                catch (Exception e)
-                {
-                    Assert.Contains("lock", e.Message.ToLower());
-                }
-            }
             using (var sessionReadOnly = _store.CreateSessionReadOnly())
             {
                 var person = await sessionReadOnly.Query<Person>().FirstOrDefaultAsync();

--- a/test/YesSql.Tests/CoreTests.cs
+++ b/test/YesSql.Tests/CoreTests.cs
@@ -5242,5 +5242,59 @@ namespace YesSql.Tests
                 }              
             }
         }
+
+        [Fact]
+        public virtual async Task ShouldNotCauseInterlockASessionReadOnly()
+        {
+            // Create initial document
+            using (var session = _store.CreateSession())
+            {
+                var email = new Person { Firstname = "Bill" };
+
+                session.Save(email);
+            }
+
+            var viewModel = new Person
+            {
+                Firstname = "",
+                Version = 0
+            };
+
+            using (var sessionOnlyForRead = _store.CreateSession())
+            {
+                var person = await sessionOnlyForRead.Query<Person>().FirstOrDefaultAsync();
+                Assert.Equal("Bill", (string)person.Firstname);
+
+                try
+                {
+                    using (var sessionForWrite = _store.CreateSession())
+                    {
+                        var personForWrite = await sessionForWrite.Query<Person>().FirstOrDefaultAsync();
+                        personForWrite.Firstname = "Jim";
+                        sessionForWrite.Save(personForWrite);
+                        sessionForWrite.CommitAsync();
+                    }
+                }
+                catch (Exception e)
+                {
+                    Assert.Contains("lock", e.Message.ToLower());
+                }
+            }
+            using (var sessionReadOnly = _store.CreateSessionReadOnly())
+            {
+                var person = await sessionReadOnly.Query<Person>().FirstOrDefaultAsync();
+                Assert.Equal("Bill", (string)person.Firstname);
+
+                using (var sessionForWrite = _store.CreateSession())
+                {
+                    var personForWrite = await sessionForWrite.Query<Person>().FirstOrDefaultAsync();
+                    personForWrite.Firstname = "Jim";
+                    sessionForWrite.Save(personForWrite);
+                    sessionForWrite.CommitAsync();
+                }
+                person = await sessionReadOnly.Query<Person>().FirstOrDefaultAsync();
+                Assert.Equal("Jim", (string)person.Firstname);
+            }
+        }
     }
 }

--- a/test/YesSql.Tests/CoreTests.cs
+++ b/test/YesSql.Tests/CoreTests.cs
@@ -5242,38 +5242,5 @@ namespace YesSql.Tests
                 }              
             }
         }
-
-        [Fact]
-        public virtual async Task ShouldNotCauseInterlockASessionReadOnly()
-        {
-            // Create initial document
-            using (var session = _store.CreateSession())
-            {
-                var email = new Person { Firstname = "Bill" };
-
-                session.Save(email);
-            }
-
-            var viewModel = new Person
-            {
-                Firstname = "",
-                Version = 0
-            };
-            using (var sessionReadOnly = _store.CreateSessionReadOnly())
-            {
-                var person = await sessionReadOnly.Query<Person>().FirstOrDefaultAsync();
-                Assert.Equal("Bill", (string)person.Firstname);
-
-                using (var sessionForWrite = _store.CreateSession())
-                {
-                    var personForWrite = await sessionForWrite.Query<Person>().FirstOrDefaultAsync();
-                    personForWrite.Firstname = "Jim";
-                    sessionForWrite.Save(personForWrite);
-                    sessionForWrite.CommitAsync();
-                }
-                person = await sessionReadOnly.Query<Person>().FirstOrDefaultAsync();
-                Assert.Equal("Jim", (string)person.Firstname);
-            }
-        }
     }
 }

--- a/test/YesSql.Tests/YesSql.Tests.csproj
+++ b/test/YesSql.Tests/YesSql.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+        <TargetFrameworks>netcoreapp2.1;net5.0</TargetFrameworks>
         <LangVersion>8.0</LangVersion>
         <AssemblyName>YesSql.Tests</AssemblyName>
         <PackageId>YesSql.Tests</PackageId>

--- a/test/YesSql.Tests/YesSql.Tests.csproj
+++ b/test/YesSql.Tests/YesSql.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1;net5.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
         <LangVersion>8.0</LangVersion>
         <AssemblyName>YesSql.Tests</AssemblyName>
         <PackageId>YesSql.Tests</PackageId>


### PR DESCRIPTION
This PR provides a new interface ISessionReadonly that allows to create sessions only for read operation. It doesn't use transactions and it doesn't cache entities at identity map. 
It is useful for helping devs to reduce the number of locks when they use YesSql and for  reducing the probability of interlocks as it is explained in this issue https://github.com/OrchardCMS/OrchardCore/issues/8705 