### PR TITLE
Handle null version column

### DIFF
--- a/src/YesSql.Core/Commands/UpdateDocumentCommand.cs
+++ b/src/YesSql.Core/Commands/UpdateDocumentCommand.cs
@@ -26,10 +26,12 @@ namespace YesSql.Commands
             var documentTable = _store.Configuration.TableNameConvention.GetDocumentTable(Collection);
 
             var updateCmd = $"update {dialect.QuoteForTableName(_store.Configuration.TablePrefix + documentTable)} "
-                + $"set {dialect.QuoteForColumnName("Content")} = @Content, {dialect.QuoteForColumnName("Version")} = @Version where " 
+                + $"set {dialect.QuoteForColumnName("Content")} = @Content, {dialect.QuoteForColumnName("Version")} = @Version where "
                 + $"{dialect.QuoteForColumnName("Id")} = @Id "
-                + (_checkVersion > -1 
-                    ? $" and {dialect.QuoteForColumnName("Version")} = {dialect.GetSqlValue(_checkVersion)} ;" 
+                + (_checkVersion > -1
+                    ? Document.Version == 1 // When the Document.Version is 0 + 1 the Version column maybe null.
+                        ? $" and ({dialect.QuoteForColumnName("Version")} IS NULL OR {dialect.QuoteForColumnName("Version")} = {dialect.GetSqlValue(_checkVersion)}) ;"
+                        : $" and {dialect.QuoteForColumnName("Version")} = {dialect.GetSqlValue(_checkVersion)} ;"
                     : ";")
                 ;
 
@@ -69,7 +71,7 @@ namespace YesSql.Commands
             batchCommand
                 .AddParameter("Id_" + index, Document.Id, DbType.Int32)
                 .AddParameter("Content_" + index, Document.Content, DbType.String)
-                .AddParameter("Version_" + index, Document.Version , DbType.Int64);
+                .AddParameter("Version_" + index, Document.Version, DbType.Int64);
 
             return true;
         }

--- a/src/YesSql.Core/Store.cs
+++ b/src/YesSql.Core/Store.cs
@@ -214,7 +214,7 @@ namespace YesSql
                                 .Column<int>(nameof(Document.Id), column => column.PrimaryKey().NotNull())
                                 .Column<string>(nameof(Document.Type), column => column.NotNull())
                                 .Column<string>(nameof(Document.Content), column => column.Unlimited())
-                                .Column<long>(nameof(Document.Version), column => column.WithDefault(0))
+                                .Column<long>(nameof(Document.Version), column => column.NotNull().WithDefault(0))
                             )
                             .AlterTable(documentTable, table => table
                                 .CreateIndex("IX_" + documentTable + "_Type", "Type")


### PR DESCRIPTION
Fixes https://github.com/sebastienros/yessql/issues/343

On SQL Server @Skrypt is right, the Version column maybe `Null` which throws concurrency exceptions, when updating settings, or any of the other Documents.

It doesn't seem to happen on SQLite as the column gets set to 0.

Here when checking the `Version` column, if it is 1, i.e was the default of 0, then incremented to 1, I've added a null check on the version column.

When the Version value is over 1, we know the column cannot be null, so get the normal sql.

(it could just always use the null check, and would be no harm, if you wanted to keep the code simpler there)

Packed locally and tested with a OrchardCore SQL database with the `Version` column reset to null, and it works now.

<img width="581" alt="Screenshot 2021-03-07 at 18 06 39" src="https://user-images.githubusercontent.com/13782679/110249926-a4a0d300-7f70-11eb-9cd1-840f1a6ef9bd.png">





