### PR TITLE
Implement hash for index and foreign key names

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,12 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
+			"name": ".NET Core Attach",
+			"type": "coreclr",
+			"request": "attach",
+			"processId": "${command:pickProcess}"
+		},
+		{
 			"name": ".NET Core Launch (Samples.Hi)",
 			"type": "coreclr",
 			"request": "launch",

--- a/src/YesSql.Abstractions/ISqlDialect.cs
+++ b/src/YesSql.Abstractions/ISqlDialect.cs
@@ -169,6 +169,16 @@ namespace YesSql
         /// Returns the ADD FOREIGN KEY constraint SQL statement.
         /// </summary>
         string GetAddForeignKeyConstraintString(string name, string[] srcColumns, string destTable, string[] destColumns, bool primaryKey);
+
+        /// <summary>
+        /// Formats a foreign key name to the length constraints of the dialect.
+        /// </summary>
+        string FormatKeyName(string name);
+
+        /// <summary>
+        /// Formats a index name to the length constraints of the dialect.
+        /// </summary>
+        string FormatIndexName(string name);        
         
         /// <summary>
         /// Returns the DISTING SELECT SQL statement.

--- a/src/YesSql.Abstractions/ISqlDialect.cs
+++ b/src/YesSql.Abstractions/ISqlDialect.cs
@@ -171,17 +171,17 @@ namespace YesSql
         string GetAddForeignKeyConstraintString(string name, string[] srcColumns, string destTable, string[] destColumns, bool primaryKey);
 
         /// <summary>
-        /// Formats a foreign key name to the length constraints of the dialect.
+        /// Formats a foreign key name to a deterministic value within the length constraints of the dialect.
         /// </summary>
         string FormatKeyName(string name);
 
         /// <summary>
-        /// Formats a index name to the length constraints of the dialect.
+        /// Formats a index name to a deterministic value within the length constraints of the dialect.
         /// </summary>
         string FormatIndexName(string name);        
         
         /// <summary>
-        /// Returns the DISTING SELECT SQL statement.
+        /// Returns the DISTINCT SELECT SQL statement.
         /// </summary>
         List<string> GetDistinctOrderBySelectString(List<string> select, List<string> orderBy);
 

--- a/src/YesSql.Core/Sql/Schema/AlterTableCommand.cs
+++ b/src/YesSql.Core/Sql/Schema/AlterTableCommand.cs
@@ -60,7 +60,7 @@ namespace YesSql.Sql.Schema
                 indexName = _tablePrefix + indexName;
             }
 
-            var command = new AddIndexCommand(Name, indexName, columnNames);
+            var command = new AddIndexCommand(Name, _dialect.FormatIndexName(indexName), columnNames);
             TableCommands.Add(command);
         }
 
@@ -71,7 +71,7 @@ namespace YesSql.Sql.Schema
                 indexName = _tablePrefix + indexName;
             }
 
-            var command = new DropIndexCommand(Name, indexName);
+            var command = new DropIndexCommand(Name, _dialect.FormatIndexName(indexName));
             TableCommands.Add(command);
         }
     }

--- a/src/YesSql.Core/Sql/SchemaBuilder.cs
+++ b/src/YesSql.Core/Sql/SchemaBuilder.cs
@@ -246,8 +246,9 @@ namespace YesSql.Sql
         {
             try
             {
-                var command = new CreateForeignKeyCommand(Prefix(name), Prefix(srcTable), srcColumns, Prefix(destTable), destColumns);
-                Execute(_commandInterpreter.CreateSql(command));
+                var command = new CreateForeignKeyCommand(Dialect.FormatKeyName(Prefix(name)), Prefix(srcTable), srcColumns, Prefix(destTable), destColumns);
+                var sql = _commandInterpreter.CreateSql(command);
+                Execute(sql);
             }
             catch
             {
@@ -264,7 +265,7 @@ namespace YesSql.Sql
         {
             try
             {
-                var command = new DropForeignKeyCommand(Prefix(srcTable), Prefix(name));
+                var command = new DropForeignKeyCommand(Dialect.FormatKeyName(Prefix(srcTable)), Prefix(name));
                 Execute(_commandInterpreter.CreateSql(command));
             }
             catch

--- a/src/YesSql.Core/Utils/HashHelper.cs
+++ b/src/YesSql.Core/Utils/HashHelper.cs
@@ -6,15 +6,20 @@ namespace YesSql.Utils
 {
     public static class HashHelper
     {
-        // Use of numeric characters is supported as long as the name does not start with a number.
+        // Use of numeric characters is supported but dialects must be prefixed with a valid character for the dialect.
         private static readonly string _encode32Chars = "0123456789abcdefghjkmnpqrstvwxyz";
 
         /// <summary>
-        /// Produces a 52 character hash.
+        /// Produces a 52 character hash with the supplied prefix prepended.
+        /// The length of the prefix plus the 52 char hash must be less than the dialects maximum length.
         /// </summary>
-        public static string HashName(string name)
+        public static string HashName(string prefix, string name)
         {
-            // Create returns a fips compatabile implementation.
+            if (string.IsNullOrEmpty(prefix))
+            {
+                throw new ArgumentNullException("A prefix is required");
+            }
+
             using (var hash = SHA256.Create())
             {
                 var bytes = Encoding.UTF8.GetBytes(name);
@@ -25,7 +30,7 @@ namespace YesSql.Utils
                 var long3 = BitConverter.ToInt64(hashed, 16);
                 var long4 = BitConverter.ToInt64(hashed, 24);
 
-                return ToBase32(long1, long2, long3, long4);
+                return prefix + ToBase32(long1, long2, long3, long4);
             }
         }
 

--- a/src/YesSql.Core/Utils/HashHelper.cs
+++ b/src/YesSql.Core/Utils/HashHelper.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace YesSql.Utils
+{
+    public static class HashHelper
+    {
+        // Use of numeric characters is supported as long as the name does not start with a number.
+        private static readonly string _encode32Chars = "0123456789abcdefghjkmnpqrstvwxyz";
+
+        /// <summary>
+        /// Produces a 52 character hash.
+        /// </summary>
+        public static string HashName(string name)
+        {
+            // Create returns a fips compatabile implementation.
+            using (var hash = SHA256.Create())
+            {
+                var bytes = Encoding.UTF8.GetBytes(name);
+                var hashed = hash.ComputeHash(bytes);
+
+                var long1 = BitConverter.ToInt64(hashed, 0);
+                var long2 = BitConverter.ToInt64(hashed, 8);
+                var long3 = BitConverter.ToInt64(hashed, 16);
+                var long4 = BitConverter.ToInt64(hashed, 24);
+
+                return ToBase32(long1, long2, long3, long4);
+            }
+        }
+
+        private static string ToBase32(long long1, long long2, long long3, long long4)
+        {
+            var charBuffer = new char[52];
+
+            int i = 0;
+
+            i = EncodeSegment(charBuffer, i, long1);
+
+            i = EncodeSegment(charBuffer, i, long2);
+
+            i = EncodeSegment(charBuffer, i, long3);
+
+            EncodeSegment(charBuffer, i, long4);
+
+            return new string(charBuffer);
+        }        
+
+        private static int EncodeSegment(char[] charBuffer, int startIndex, long lng)
+        {
+            charBuffer[startIndex] = _encode32Chars[(int)(lng >> 60) & 31];
+            charBuffer[startIndex + 1] = _encode32Chars[(int)(lng >> 55) & 31];
+            charBuffer[startIndex + 2] = _encode32Chars[(int)(lng >> 50) & 31];
+            charBuffer[startIndex + 3] = _encode32Chars[(int)(lng >> 45) & 31];
+            charBuffer[startIndex + 4] = _encode32Chars[(int)(lng >> 40) & 31];
+            charBuffer[startIndex + 5] = _encode32Chars[(int)(lng >> 35) & 31];
+            charBuffer[startIndex + 6] = _encode32Chars[(int)(lng >> 30) & 31];
+            charBuffer[startIndex + 7] = _encode32Chars[(int)(lng >> 25) & 31];
+            charBuffer[startIndex + 8] = _encode32Chars[(int)(lng >> 20) & 31];
+            charBuffer[startIndex + 9] = _encode32Chars[(int)(lng >> 15) & 31];
+            charBuffer[startIndex + 10] = _encode32Chars[(int)(lng >> 10) & 31];
+            charBuffer[startIndex + 11] = _encode32Chars[(int)(lng >> 5) & 31];
+            charBuffer[startIndex + 12] = _encode32Chars[(int)lng & 31];
+
+            return startIndex + 13;
+        }
+    }
+}

--- a/src/YesSql.Provider.Common/BaseDialect.cs
+++ b/src/YesSql.Provider.Common/BaseDialect.cs
@@ -119,6 +119,9 @@ namespace YesSql.Provider
 
         public virtual bool SupportsForeignKeyConstraintInAlterTable => true;
 
+        public virtual string FormatKeyName(string name) => name;
+        public virtual string FormatIndexName(string name) => name;
+
         public virtual string GetAddForeignKeyConstraintString(string name, string[] srcColumns, string destTable, string[] destColumns, bool primaryKey)
         {
             var res = new StringBuilder(200);

--- a/src/YesSql.Provider.MySql/MySqlDialect.cs
+++ b/src/YesSql.Provider.MySql/MySqlDialect.cs
@@ -165,9 +165,11 @@ namespace YesSql.Provider.MySql
 
         public override string FormatKeyName(string name)
         {
+            // https://dev.mysql.com/doc/refman/8.0/en/identifier-length.html
+            // MySql limits identifiers to 64 char.
             if (name.Length >= 64)
             {
-                return "FK_" + HashHelper.HashName(name);
+                return HashHelper.HashName("FK_", name);
             }
 
             return name;
@@ -175,9 +177,11 @@ namespace YesSql.Provider.MySql
 
         public override string FormatIndexName(string name)
         {
+            // https://dev.mysql.com/doc/refman/8.0/en/identifier-length.html
+            // MySql limits identifiers to 64 char.
             if (name.Length >= 64)
             {
-                return "IDX_FK_" + HashHelper.HashName(name);
+                return HashHelper.HashName("IDX_FK_", name);
             }
 
             return name;

--- a/src/YesSql.Provider.MySql/MySqlDialect.cs
+++ b/src/YesSql.Provider.MySql/MySqlDialect.cs
@@ -4,6 +4,7 @@ using System.Data;
 using System.Globalization;
 using System.Text;
 using YesSql.Sql;
+using YesSql.Utils;
 
 namespace YesSql.Provider.MySql
 {
@@ -151,7 +152,7 @@ namespace YesSql.Provider.MySql
 
             if (_columnTypes.TryGetValue(dbType, out string value))
             {
-                if(dbType == DbType.Decimal)
+                if (dbType == DbType.Decimal)
                 {
                     value = string.Format(value, precision ?? DefaultDecimalPrecision, scale ?? DefaultDecimalScale);
                 }
@@ -162,9 +163,29 @@ namespace YesSql.Provider.MySql
             throw new Exception("DbType not found for: " + dbType);
         }
 
+        public override string FormatKeyName(string name)
+        {
+            if (name.Length >= 64)
+            {
+                return "FK_" + HashHelper.HashName(name);
+            }
+
+            return name;
+        }
+
+        public override string FormatIndexName(string name)
+        {
+            if (name.Length >= 64)
+            {
+                return "IDX_FK_" + HashHelper.HashName(name);
+            }
+
+            return name;
+        }        
+
         public override string GetDropForeignKeyConstraintString(string name)
         {
-            return " drop foreign key " + name;
+            return " drop foreign key " + FormatKeyName(name);
         }
 
         public override string GetAddForeignKeyConstraintString(string name, string[] srcColumns, string destTable, string[] destColumns, bool primaryKey)

--- a/src/YesSql.Provider.PostgreSql/PostgreSqlDialect.cs
+++ b/src/YesSql.Provider.PostgreSql/PostgreSqlDialect.cs
@@ -152,9 +152,11 @@ namespace YesSql.Provider.PostgreSql
 
         public override string FormatKeyName(string name)
         {
+            // https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+            // Postgres limits identifiers to NAMEDATALEN-1 char, where NAMEDATALEN is 64.
             if (name.Length >= 63)
             {
-                return "FK_" + HashHelper.HashName(name);
+                return HashHelper.HashName("FK_", name);
             }
 
             return name;
@@ -162,9 +164,11 @@ namespace YesSql.Provider.PostgreSql
         
         public override string FormatIndexName(string name)
         {
+            // https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+            // Postgres limits identifiers to NAMEDATALEN-1 char, where NAMEDATALEN is 64.
             if (name.Length >= 63)
             {
-                return "IDX_FK_" + HashHelper.HashName(name);
+                return HashHelper.HashName("IDX_FK_", name);
             }
 
             return name;

--- a/src/YesSql.Provider.PostgreSql/PostgreSqlDialect.cs
+++ b/src/YesSql.Provider.PostgreSql/PostgreSqlDialect.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Globalization;
 using YesSql.Sql;
+using YesSql.Utils;
 
 namespace YesSql.Provider.PostgreSql
 {
@@ -149,6 +150,25 @@ namespace YesSql.Provider.PostgreSql
             throw new Exception("DbType not found for: " + dbType);
         }
 
+        public override string FormatKeyName(string name)
+        {
+            if (name.Length >= 63)
+            {
+                return "FK_" + HashHelper.HashName(name);
+            }
+
+            return name;
+        }
+        
+        public override string FormatIndexName(string name)
+        {
+            if (name.Length >= 63)
+            {
+                return "IDX_FK_" + HashHelper.HashName(name);
+            }
+
+            return name;
+        }  
         public override string GetDropForeignKeyConstraintString(string name)
         {
             return " drop foreign key " + name;

--- a/test/YesSql.Tests/CoreTests.cs
+++ b/test/YesSql.Tests/CoreTests.cs
@@ -234,11 +234,11 @@ namespace YesSql.Tests
                             "Col1"
                             );
 
-                   builder.CreateReduceIndexTable<PersonsByNameCol>(column => column
+                    builder.CreateReduceIndexTable<PersonsByNameCol>(column => column
                             .Column<string>(nameof(PersonsByNameCol.Name))
                             .Column<int>(nameof(PersonsByNameCol.Count)),
                             "Col1"
-                            );                            
+                            );                                                        
 
                     transaction.Commit();
                 }

--- a/test/YesSql.Tests/HashHelperTests.cs
+++ b/test/YesSql.Tests/HashHelperTests.cs
@@ -1,0 +1,24 @@
+using Xunit;
+using YesSql.Utils;
+
+namespace YesSql.Tests
+{
+    public class HashHelperTests
+    {
+        private const string _longKeyName = "MyTablePrefix_FK_LongCollectionName_LongIndexTableName_LongCollectionName_Document_DocumentId";
+
+        [Fact]
+        public void ShouldBeDeterministic()
+        {
+            var first = HashHelper.HashName(_longKeyName);
+            var second = HashHelper.HashName(_longKeyName);
+            Assert.Equal(first, second);
+        }
+
+        [Fact]
+        public void ShouldBe52Chars()
+        {
+            Assert.Equal(52, HashHelper.HashName(_longKeyName).Length);
+        }
+    }
+}

--- a/test/YesSql.Tests/HashHelperTests.cs
+++ b/test/YesSql.Tests/HashHelperTests.cs
@@ -10,15 +10,16 @@ namespace YesSql.Tests
         [Fact]
         public void ShouldBeDeterministic()
         {
-            var first = HashHelper.HashName(_longKeyName);
-            var second = HashHelper.HashName(_longKeyName);
+            var first = HashHelper.HashName("FK_", _longKeyName);
+            var second = HashHelper.HashName("FK_", _longKeyName);
             Assert.Equal(first, second);
         }
 
         [Fact]
-        public void ShouldBe52Chars()
+        public void ShouldBe55Chars()
         {
-            Assert.Equal(52, HashHelper.HashName(_longKeyName).Length);
+            // 52 + FK_ = 55
+            Assert.Equal(55, HashHelper.HashName("FK_", _longKeyName).Length);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/sebastienros/yessql/issues/361

Ended up with implementations on the dialect for both

`FormatKeyName` and `FormatIndexName` as they are for slightly different requirements.

The `HashHelper` went in utils, for want of a better place, to save having it in both postgres and mysql.

You'll recognise the design, just base 32. Kept them lowercase as it is more obvious that it's been generated.

but prefixed with `IDX_FK_` or `FK_`

Would have potentially been nice to keep the table prefix in, but became more complicated. So kept it simple

<img width="884" alt="Screenshot 2021-03-24 at 16 07 57" src="https://user-images.githubusercontent.com/13782679/112352033-5571d680-8cc2-11eb-9eed-eb833069c593.png">
