### PR TITLE
AllAsync and AnyAsync

### DIFF
--- a/src/YesSql.Abstractions/IQuery.cs
+++ b/src/YesSql.Abstractions/IQuery.cs
@@ -39,9 +39,19 @@ namespace YesSql
         IQuery<T> Any(params Func<IQuery<T>, IQuery<T>>[] predicates);
 
         /// <summary>
+        /// Filters any predicates on newly joined indexes.
+        /// </summary>
+        ValueTask<IQuery<T>> AnyAsync(params Func<IQuery<T>, ValueTask<IQuery<T>>>[] predicates);
+
+        /// <summary>
         /// Filters all predicates on newly joined indexes.
         /// </summary>
         IQuery<T> All(params Func<IQuery<T>, IQuery<T>>[] predicates);
+
+        /// <summary>
+        /// Filters all predicates on newly joined indexes.
+        /// </summary>
+        ValueTask<IQuery<T>> AllAsync(params Func<IQuery<T>, ValueTask<IQuery<T>>>[] predicates);
 
         /// <summary>
         /// Filters the documents with a record in the specified index.

--- a/src/YesSql.Core/Services/DefaultQuery.cs
+++ b/src/YesSql.Core/Services/DefaultQuery.cs
@@ -1291,11 +1291,33 @@ namespace YesSql.Services
                 return query;
             }
 
+            ValueTask<IQuery<T>> IQuery<T>.AnyAsync(params Func<IQuery<T>, ValueTask<IQuery<T>>>[] predicates)
+            {
+                // Scope the currentPredicate so multiple calls will not act on the new predicate.
+                var currentPredicate = _query._queryState._currentPredicate;
+                var query = ComposeQueryAsync(predicates, new OrNode());
+                // Return the currentPredicate to it's previous value, so another method call will act on the previous predicate.
+                _query._queryState._currentPredicate = currentPredicate;
+
+                return query;
+            }
+
             IQuery<T> IQuery<T>.All(params Func<IQuery<T>, IQuery<T>>[] predicates)
             {
                 // Scope the currentPredicate so multiple calls will not act on the new predicate.
                 var currentPredicate = _query._queryState._currentPredicate;
                 var query = ComposeQuery(predicates, new AndNode());
+                // Return the currentPredicate to it's previous value, so another method call will act on the previous predicate.
+                _query._queryState._currentPredicate = currentPredicate;
+
+                return query;
+            }
+
+            ValueTask<IQuery<T>> IQuery<T>.AllAsync(params Func<IQuery<T>, ValueTask<IQuery<T>>>[] predicates)
+            {
+                // Scope the currentPredicate so multiple calls will not act on the new predicate.
+                var currentPredicate = _query._queryState._currentPredicate;
+                var query = ComposeQueryAsync(predicates, new AndNode());
                 // Return the currentPredicate to it's previous value, so another method call will act on the previous predicate.
                 _query._queryState._currentPredicate = currentPredicate;
 
@@ -1319,6 +1341,24 @@ namespace YesSql.Services
 
                 return new Query<T>(_query);
             }
+
+            private async ValueTask<IQuery<T>> ComposeQueryAsync(Func<IQuery<T>, ValueTask<IQuery<T>>>[] predicates, CompositeNode predicate)
+            {
+                _query._queryState._currentPredicate.Children.Add(predicate);
+
+                _query._queryState._currentPredicate = predicate;
+
+                foreach (var p in predicates)
+                {
+                    var name = "a" + (_query._queryState._bindings.Count + 1);
+                    _query._queryState._bindingName = name;
+                    _query._queryState._bindings.Add(name, new List<Type>());
+
+                    await p(this);
+                }
+
+                return new Query<T>(_query);
+            }            
 
             IQuery<T, TIndex> IQuery<T>.With<TIndex>()
             {


### PR DESCRIPTION
Replaces https://github.com/sebastienros/yessql/pull/369 

Easier to do another than deal with the merge conflicts.

`ValueTask` this time, since you already used it.

Adds some async overloads for .Any and .All

Bit of code duplication here, hopefully is ok :)

Allows to create async functions, that can then be passed into these methods.