### PR TITLE
Clear query order when adding new order statements

### DIFF
--- a/src/YesSql.Core/Sql/SqlBuilder.cs
+++ b/src/YesSql.Core/Sql/SqlBuilder.cs
@@ -219,17 +219,20 @@ namespace YesSql.Sql
 
         public virtual void OrderBy(string orderBy)
         {
+            OrderSegments.Clear();
             OrderSegments.Add(orderBy);
         }
 
         public virtual void OrderByDescending(string orderBy)
         {
+            OrderSegments.Clear();
             OrderSegments.Add(orderBy);
             OrderSegments.Add(" DESC");
         }
 
         public virtual void OrderByRandom()
         {
+            OrderSegments.Clear();
             OrderSegments.Add(_dialect.RandomOrderByClause);
         }
 

--- a/test/YesSql.Tests/CoreTests.cs
+++ b/test/YesSql.Tests/CoreTests.cs
@@ -1954,6 +1954,40 @@ namespace YesSql.Tests
         }
 
         [Fact]
+        public async Task ShouldClearOrders()
+        {
+            _store.RegisterIndexes<PersonIndexProvider>();
+
+            using (var session = _store.CreateSession())
+            {
+                var bill = new Person
+                {
+                    Firstname = "Bill",
+                    Lastname = "Gates",
+                };
+
+                var steve = new Person
+                {
+                    Firstname = "Steve",
+                    Lastname = "Balmer"
+                };
+
+                session.Save(bill);
+                session.Save(steve);
+
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = _store.CreateSession())
+            {
+                var query = session.Query<Person, PersonByName>().OrderByDescending(x => x.SomeName);
+                query.OrderByDescending(x => x.SomeName);
+
+                Assert.Equal("Steve", (await query.FirstOrDefaultAsync()).Firstname);
+            }
+        }
+        
+        [Fact]
         public async Task ShouldJoinReduceIndex()
         {
             _store.RegisterIndexes<ArticleIndexProvider>();


### PR DESCRIPTION
When building queries through lots of abstraction interfaces, it's useful sometimes to be able to provide a default `OrderBy` and then later set another order statement.

This makes this possible, by clearing the statements if another is added later (otherwise it just gets confused when building the sql)