### PR TITLE
Adds AlwaysRun feature to filters

### DIFF
--- a/samples/YesSql.Samples.Web/Controllers/HomeController.cs
+++ b/samples/YesSql.Samples.Web/Controllers/HomeController.cs
@@ -44,16 +44,24 @@ namespace YesSql.Samples.Web.Controllers
                 var search = new Filter
                 {
                     SearchText = currentSearchText,
-                    OriginalSearchText = currentSearchText,
-                    Filters = new List<SelectListItem>()
-                    {
-                        new SelectListItem("Select...", ""),
-                        new SelectListItem("Published", ContentsStatus.Published.ToString()),
-                        new SelectListItem("Draft", ContentsStatus.Draft.ToString())
-                    }
+                    OriginalSearchText = currentSearchText
                 };
 
                 filterResult.MapTo(search);
+
+
+                search.Statuses = new List<SelectListItem>()
+                {
+                    new SelectListItem("Select...", "", search.SelectedStatus == BlogPostStatus.Default),
+                    new SelectListItem("Published", BlogPostStatus.Published.ToString(), search.SelectedStatus == BlogPostStatus.Published),
+                    new SelectListItem("Draft", BlogPostStatus.Draft.ToString(), search.SelectedStatus == BlogPostStatus.Draft)
+                };
+
+                search.Sorts = new List<SelectListItem>()
+                {
+                    new SelectListItem("Newest", BlogPostSort.Newest.ToString(), search.SelectedSort == BlogPostSort.Newest),
+                    new SelectListItem("Oldest", BlogPostSort.Oldest.ToString(), search.SelectedSort == BlogPostSort.Oldest)
+                };                
 
                 var vm = new BlogPostViewModel
                 {

--- a/samples/YesSql.Samples.Web/Startup.cs
+++ b/samples/YesSql.Samples.Web/Startup.cs
@@ -34,14 +34,14 @@ namespace YesSql.Samples.Web
                     .WithNamedTerm("status", builder => builder
                         .OneCondition((val, query) =>
                         {
-                            if (Enum.TryParse<ContentsStatus>(val, true, out var e))
+                            if (Enum.TryParse<BlogPostStatus>(val, true, out var e))
                             {
                                 switch (e)
                                 {
-                                    case ContentsStatus.Published:
+                                    case BlogPostStatus.Published:
                                         query.With<BlogPostIndex>(x => x.Published);
                                         break;
-                                    case ContentsStatus.Draft:
+                                    case BlogPostStatus.Draft:
                                         query.With<BlogPostIndex>(x => !x.Published);
                                         break;
                                     default:
@@ -53,21 +53,65 @@ namespace YesSql.Samples.Web
                         })
                         .MapTo<Filter>((val, model) =>
                         {
-                            if (Enum.TryParse<ContentsStatus>(val, true, out var e))
+                            if (Enum.TryParse<BlogPostStatus>(val, true, out var e))
                             {
-                                model.SelectedFilter = e;
+                                model.SelectedStatus = e;
                             }
                         })
                         .MapFrom<Filter>((model) =>
                         {
-                            if (model.SelectedFilter != ContentsStatus.Default)
+                            if (model.SelectedStatus != BlogPostStatus.Default)
                             {
-                                return (true, model.SelectedFilter.ToString());
+                                return (true, model.SelectedStatus.ToString());
                             }
 
                             return (false, String.Empty);
 
                         })
+                    )
+                    .WithNamedTerm("sort", b => b
+                        .OneCondition((val, query) =>
+                        {
+                            if (Enum.TryParse<BlogPostSort>(val, true, out var e))
+                            {
+                                switch (e)
+                                {
+                                    case BlogPostSort.Newest:
+                                        query.With<BlogPostIndex>().OrderByDescending(x => x.PublishedUtc);
+                                        break;
+                                    case BlogPostSort.Oldest:
+                                        query.With<BlogPostIndex>().OrderBy(x => x.PublishedUtc);
+                                        break;
+                                    default:
+                                        query.With<BlogPostIndex>().OrderByDescending(x => x.PublishedUtc);
+                                        break;
+                                }
+                            }
+                            else
+                            {
+                                query.With<BlogPostIndex>().OrderByDescending(x => x.PublishedUtc);
+                            }
+
+                            return query;          
+                        })
+                        .MapTo<Filter>((val, model) =>
+                        {
+                            if (Enum.TryParse<BlogPostSort>(val, true, out var e))
+                            {
+                                model.SelectedSort = e;
+                            }
+                        })
+                        .MapFrom<Filter>((model) =>
+                        {
+                            if (model.SelectedSort != BlogPostSort.Newest)
+                            {
+                                return (true, model.SelectedSort.ToString());
+                            }
+
+                            return (false, String.Empty);
+
+                        })
+                        .AlwaysRun()
                     )
                     .WithDefaultTerm("title", b => b
                         .ManyCondition(

--- a/samples/YesSql.Samples.Web/ViewModels/BlogPostViewModel.cs
+++ b/samples/YesSql.Samples.Web/ViewModels/BlogPostViewModel.cs
@@ -19,19 +19,29 @@ namespace YesSql.Samples.Web.ViewModels
         public string Author { get; set; }
         public string SearchText { get; set; }
         public string OriginalSearchText { get; set; }
-        public ContentsStatus SelectedFilter { get; set; }
+        public BlogPostStatus SelectedStatus { get; set; }
+        public BlogPostSort SelectedSort { get; set; }
 
-        [ModelBinder(BinderType = typeof(QueryFilterEngineModelBinder<BlogPost>), Name = "SearchText")]
+        [ModelBinder(BinderType = typeof(QueryFilterEngineModelBinder<BlogPost>), Name = nameof(SearchText))]
         public QueryFilterResult<BlogPost> FilterResult { get; set; }
 
         [BindNever]
-        public List<SelectListItem> Filters { get; set; } = new();
+        public List<SelectListItem> Statuses { get; set; } = new();
+
+        [BindNever]
+        public List<SelectListItem> Sorts { get; set; } = new();
     }
 
-    public enum ContentsStatus
+    public enum BlogPostStatus
     {
         Default,
         Draft,
         Published
+    }
+
+    public enum BlogPostSort
+    {
+        Newest,
+        Oldest,
     }
 }

--- a/samples/YesSql.Samples.Web/Views/Home/Index.cshtml
+++ b/samples/YesSql.Samples.Web/Views/Home/Index.cshtml
@@ -8,6 +8,36 @@
 </head>
 
 <body class="m-5">
+
+    <form asp-action="IndexPost" method="post">
+        <input type="search" asp-for="Search.OriginalSearchText" type="hidden"></input>
+        
+
+        <div class="form-group row mb-3">
+            <label asp-for="Search.SearchText" class="col-2 align-self-center">Search</label>
+            <div class="col-10">
+                <input class="form-control" type="search" asp-for="Search.SearchText"></input>
+            </div>
+        </div>
+
+        <div class="form-group row mb-3">
+            <label asp-for="Search.SelectedStatus" class="col-2 align-self-center">Status</label>
+            <div class="col-10">
+                <select class="form-control" asp-for="Search.SelectedStatus" asp-items="Model.Search.Statuses"></select>
+            </div>
+        </div>
+
+        <div class="form-group row mb-3">
+            <label asp-for="Search.SelectedSort" class="col-2 align-self-center">Sort</label>
+            <div class="col-10">
+                <select class="form-control" asp-for="Search.SelectedSort" asp-items="Model.Search.Sorts"></select>
+            </div>     
+
+        </div>
+   
+        <button class="btn btn-primary d-flex ms-auto mb-3" type="submit">Search</button>   
+    </form>
+
     @foreach (var blogPost in Model.BlogPosts)
     {
         <div class="card">
@@ -19,18 +49,5 @@
         </div>
     }
 
-    <form asp-action="IndexPost" method="post">
-        <input type="search" asp-for="Search.OriginalSearchText" type="hidden"></input>
 
-        <div class="w-100 form-group my-3">
-            <input class="form-control" type="search" asp-for="Search.SearchText"></input>
-        </div>
-
-
-        <div class="w-50 form-group my-3">
-            <select class="form-control" asp-for="Search.SelectedFilter" asp-items="Model.Search.Filters"></select>
-        </div>
-
-        <button class="btn btn-primary d-block my-3" type="submit">Search</button>
-    </form>
 </body>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
         <Copyright>Sebastien Ros</Copyright>
         <Authors>Sebastien Ros</Authors>
         <TargetFrameworks>net451;netstandard1.5;netstandard2.0</TargetFrameworks>
-        <VersionSuffix>beta</VersionSuffix>
+        <VersionSuffix>alpha</VersionSuffix>
         <VersionSuffix Condition="'$(VersionSuffix)'!='' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <DebugType>portable</DebugType>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
         <Copyright>Sebastien Ros</Copyright>
         <Authors>Sebastien Ros</Authors>
         <TargetFrameworks>net451;netstandard1.5;netstandard2.0</TargetFrameworks>
-        <VersionSuffix>alpha</VersionSuffix>
+        <VersionSuffix>beta</VersionSuffix>
         <VersionSuffix Condition="'$(VersionSuffix)'!='' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <DebugType>portable</DebugType>

--- a/src/YesSql.Filters.Abstractions/Builders/UnaryEngineBuilder.cs
+++ b/src/YesSql.Filters.Abstractions/Builders/UnaryEngineBuilder.cs
@@ -26,6 +26,13 @@ namespace YesSql.Filters.Abstractions.Builders
 
             return this;
         }
+        
+        public UnaryEngineBuilder<T, TTermOption> AlwaysRun()
+        {
+            _termOption.AlwaysRun = true;
+
+            return this;
+        }
 
         public override (Parser<OperatorNode> Parser, TTermOption TermOption) Build()
             => (_parser, _termOption);

--- a/src/YesSql.Filters.Abstractions/Services/FilterResult.cs
+++ b/src/YesSql.Filters.Abstractions/Services/FilterResult.cs
@@ -9,7 +9,7 @@ namespace YesSql.Filters.Abstractions.Services
     public abstract class FilterResult<T, TTermOption> : IEnumerable<TermNode> where TTermOption : TermOption
     {
 
-        protected Dictionary<string, TermNode> _terms = new Dictionary<string, TermNode>();
+        protected Dictionary<string, TermNode> _terms = new Dictionary<string, TermNode>(StringComparer.OrdinalIgnoreCase);
 
         public FilterResult(IReadOnlyDictionary<string, TTermOption> termOptions)
         {

--- a/src/YesSql.Filters.Abstractions/Services/TermOption.cs
+++ b/src/YesSql.Filters.Abstractions/Services/TermOption.cs
@@ -17,6 +17,11 @@ namespace YesSql.Filters.Abstractions.Services
         /// </summary>
         public bool Single { get; set; } = true;
 
+        /// <summary>
+        /// Whether this term filter should always run, even when not specified.
+        /// </summary>
+        public bool AlwaysRun { get; set; } = false;
+
         public Delegate MapTo { get; set; }
         public Delegate MapFrom { get; set; }
         public Func<string, string, TermNode> MapFromFactory { get; set; }

--- a/src/YesSql.Filters.Query/QueryEngineBuilder.cs
+++ b/src/YesSql.Filters.Query/QueryEngineBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using YesSql.Filters.Abstractions.Builders;
@@ -24,7 +25,7 @@ namespace YesSql.Filters.Query
             var builders = _termBuilders.Values.Select(x => x.Build());
 
             var parsers = builders.Select(x => x.Parser).ToArray();
-            var termOptions = builders.Select(x => x.TermOption).ToDictionary(k => k.Name, v => v);
+            var termOptions = builders.Select(x => x.TermOption).ToDictionary(k => k.Name, v => v, StringComparer.OrdinalIgnoreCase);
 
             return new QueryParser<T>(parsers, termOptions);
         }


### PR DESCRIPTION
This adds an `AlwaysRun` feature to filters, so that filters that need to provide defaults for sorting etc, are always run, even when not supplied in the filter query string.

When they `AlwaysRun` they are rendered back as part of the filter string provided to the UI (to save rendering all the defaults in the UI)

Plus cleaning up the sample project a bit to demo it.

wiki docs still to come ;)