### PR TITLE
Fix last binding

### DIFF
--- a/src/YesSql.Core/Services/DefaultQuery.cs
+++ b/src/YesSql.Core/Services/DefaultQuery.cs
@@ -397,8 +397,18 @@ namespace YesSql.Services
 
         private void Bind(Type tIndex)
         {
-            if (_queryState.GetBindings().Contains(tIndex))
+            var bindings = _queryState.GetBindings();
+            var bindingIndex = bindings.IndexOf(tIndex);
+            if (bindingIndex != -1)
             {
+                // When a binding is reused it should be last to be correctly applied to a filter predicate.
+                if (bindingIndex != bindings.Count -1)
+                {
+                    var binding = bindings[bindingIndex];
+                    bindings.RemoveAt(bindingIndex);
+                    bindings.Insert(bindings.Count, binding);
+                }
+
                 return;
             }
 


### PR DESCRIPTION
When there are multiple indexes being bound to the same query it should not matter which order the `.With<TIndex>` predicates are added.

This just always makes the last `.With<TIndex>` the last item in the bindings list so that this works correctly
https://github.com/sebastienros/yessql/blob/6681e3d7053f1d8d0fac623aa78bf7dda6ff75a6/src/YesSql.Core/Services/DefaultQuery.cs#L703
