### PR TITLE
Fix whitespace issues with filters

### DIFF
--- a/src/YesSql.Filters.Abstractions/Nodes/OperatorNodes.cs
+++ b/src/YesSql.Filters.Abstractions/Nodes/OperatorNodes.cs
@@ -71,7 +71,7 @@ namespace YesSql.Filters.Abstractions.Nodes
             => $"({Left.ToNormalizedString()} OR {Right.ToNormalizedString()})";
 
         public override string ToString()
-            => $"{Left.ToString()} {Value} {Right.ToString()}";
+            => String.IsNullOrWhiteSpace(Value) ? $"{Left.ToString()} {Right.ToString()}" : $"{Left.ToString()} {Value} {Right.ToString()}";
     }
 
     public class AndNode : OperatorNode

--- a/test/YesSql.Tests/Filters/QueryEngineTests.cs
+++ b/test/YesSql.Tests/Filters/QueryEngineTests.cs
@@ -236,6 +236,19 @@ namespace YesSql.Tests.Filters
             Assert.Equal(normalized, result.ToNormalizedString());
         }
 
+        [Theory]
+        [InlineData("title:bill steve")]
+        public void ShouldNotIncludeExtraWhitespace(string search)
+        {
+            var parser = new QueryEngineBuilder<Article>()
+                .WithNamedTerm("title", b => b.ManyCondition(ArticleManyMatch(), ArticleManyNotMatch()))
+                .Build();
+
+            var result = parser.Parse(search);
+
+            Assert.Equal(search, result.ToString());
+        }        
+
         [Fact]
         public void ShouldIgnoreMultipleNamedTerms()
         {


### PR DESCRIPTION
Default filter was applying to much whitespace to `OR` expressions