### PR TITLE
Support pre 2014 SQL SERVER version drop table

### DIFF
--- a/src/YesSql.Provider.SqlServer/SqlServerDialect.cs
+++ b/src/YesSql.Provider.SqlServer/SqlServerDialect.cs
@@ -196,6 +196,11 @@ namespace YesSql.Provider.SqlServer
             }
         }
 
+        public override string GetDropTableString(string name)
+        {
+            return string.Format("if object_id('{0}','U') is not null drop table {0} ", QuoteForTableName(name));
+        }
+
         public override string GetDropIndexString(string indexName, string tableName)
         {
             return "drop index if exists " + QuoteForColumnName(indexName) + " on " + QuoteForTableName(tableName);


### PR DESCRIPTION
Hi I got some errors while droping table in a SQL 2012 instance. Then I saw DROP TABLE IF EXISTS wasn't supported on that version.
![unnamed (1)](https://user-images.githubusercontent.com/6726578/161494767-e460330c-b4e1-45bb-b6af-fbf1e567f7f7.png)

With this pr we can drop tables in every SQL Server version implementing the GetDropTableString method for SQL Server provider for YesSql

