### PR TITLE
Add TableNameAttribute - fix #442

### DIFF
--- a/samples/YesSql.Samples.Performance/Properties/launchSettings.json
+++ b/samples/YesSql.Samples.Performance/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "WSL": {
+      "commandName": "WSL2",
+      "distributionName": ""
+    }
+  }
+}

--- a/src/YesSql.Abstractions/TableNameAttribute.cs
+++ b/src/YesSql.Abstractions/TableNameAttribute.cs
@@ -1,11 +1,11 @@
-﻿using System;
+using System;
 
-namespace YesSql.Services
+namespace YesSql
 {
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
     public class TableNameAttribute : Attribute
     {
-        public string Name { get; } = String.Empty;
+        public string Name { get; }
 
         public TableNameAttribute(string tableName)
         {

--- a/src/YesSql.Core/Services/DefaultTableNameConvention.cs
+++ b/src/YesSql.Core/Services/DefaultTableNameConvention.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Linq;
+using System.Reflection;
 
 namespace YesSql.Services
 {
@@ -11,7 +11,7 @@ namespace YesSql.Services
         {
             var tableName = type.Name;
 
-            var attribute = type.GetCustomAttributes(false).Cast<TableNameAttribute>().FirstOrDefault();
+            var attribute = type.GetCustomAttribute<TableNameAttribute>();
 
             if (attribute != null && !String.IsNullOrEmpty(attribute.Name))
             {

--- a/src/YesSql.Core/Services/DefaultTableNameConvention.cs
+++ b/src/YesSql.Core/Services/DefaultTableNameConvention.cs
@@ -1,16 +1,26 @@
 using System;
+using System.Linq;
 
 namespace YesSql.Services
 {
     public class DefaultTableNameConvention : ITableNameConvention
     {
         public const string DocumentTable = "Document";
-        
+
         public string GetIndexTable(Type type, string collection = null)
         {
+            var tableName = type.Name;
+
+            var attribute = type.GetCustomAttributes(false).Cast<TableNameAttribute>().FirstOrDefault();
+
+            if (attribute != null && !String.IsNullOrEmpty(attribute.Name))
+            {
+                tableName = attribute.Name;
+            }
+
             if (String.IsNullOrEmpty(collection))
             {
-                return type.Name;
+                return tableName;
             }
 
             return collection + "_" + type.Name;
@@ -24,7 +34,6 @@ namespace YesSql.Services
             }
 
             return collection + "_" + DocumentTable;
-
         }
     }
 }

--- a/src/YesSql.Core/Services/TableNameAttribute.cs
+++ b/src/YesSql.Core/Services/TableNameAttribute.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace YesSql.Services
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+    public class TableNameAttribute : Attribute
+    {
+        public string Name { get; } = String.Empty;
+
+        public TableNameAttribute(string tableName)
+        {
+            if (String.IsNullOrEmpty(tableName))
+            {
+                throw new ArgumentNullException(nameof(tableName));
+            }
+
+            Name = tableName;
+        }
+    }
+}

--- a/test/YesSql.Tests/Indexes/PersonByName.cs
+++ b/test/YesSql.Tests/Indexes/PersonByName.cs
@@ -1,9 +1,11 @@
 using System.Threading.Tasks;
 using YesSql.Indexes;
+using YesSql.Services;
 using YesSql.Tests.Models;
 
 namespace YesSql.Tests.Indexes
 {
+    [TableName("PersonByNames")]
     public class PersonByName : MapIndex
     {
         public string SomeName { get; set; }


### PR DESCRIPTION
 Add `TableNameAttribute` to allow overriding the table name.

Fixes #442