### PR TITLE
Fix MySQL DateTimeOffset serialization

### DIFF
--- a/src/YesSql.Provider.MySql/MySqlDialect.cs
+++ b/src/YesSql.Provider.MySql/MySqlDialect.cs
@@ -86,6 +86,7 @@ namespace YesSql.Provider.MySql
         public MySqlDialect()
         {
             AddTypeHandler<TimeSpan, long>(x => x.Ticks);
+            AddTypeHandler<DateTimeOffset, string>(x => x.ToString("O"));
             Methods.Add("now", new TemplateFunction("UTC_TIMESTAMP()"));
         }
 

--- a/src/YesSql.Provider.MySql/YesSql.Provider.MySql.csproj
+++ b/src/YesSql.Provider.MySql/YesSql.Provider.MySql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <PackageReference Include="MySqlConnector" Version="2.1.0" />
+        <PackageReference Include="MySqlConnector" Version="2.1.13" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\YesSql.Core\YesSql.Core.csproj" />

--- a/test/YesSql.Tests/CoreTests.cs
+++ b/test/YesSql.Tests/CoreTests.cs
@@ -71,6 +71,12 @@ namespace YesSql.Tests
             return Task.CompletedTask;
         }
 
+        protected void EnableLogging()
+        {
+            var logger = new ConsoleLogger(_output);
+            _store.Configuration.Logger = logger;
+        }
+
         //[DebuggerNonUserCode]
         protected virtual void CleanDatabase(IConfiguration configuration, bool throwOnError)
         {
@@ -103,6 +109,7 @@ namespace YesSql.Tests
             builder.DropMapIndexTable<PersonByNameCol>("Col1");
             builder.DropMapIndexTable<PersonByBothNamesCol>("Col1");
             builder.DropReduceIndexTable<PersonsByNameCol>("Col1");
+            builder.DropReduceIndexTable<PersonsByNameCol>("LongCollection");
 
             builder.DropTable(configuration.TableNameConvention.GetDocumentTable("Col1"));
             builder.DropTable(configuration.TableNameConvention.GetDocumentTable(""));
@@ -700,11 +707,6 @@ namespace YesSql.Tests
         [Fact]
         public async Task ShouldQueryNullVariables()
         {
-            var logger = new ConsoleLogger(_output);
-
-            _store.Configuration.Logger = logger;
-
-
             _store.RegisterIndexes<PersonIndexProvider>();
 
             using (var session = _store.CreateSession())
@@ -1046,10 +1048,6 @@ namespace YesSql.Tests
         [Fact]
         public async Task ShouldQueryWithCompiledQueries()
         {
-            var logger = new ConsoleLogger(_output);
-
-            _store.Configuration.Logger = logger;
-
             _store.RegisterIndexes<PersonAgeIndexProvider>();
 
             using (var session = _store.CreateSession())

--- a/test/YesSql.Tests/MySqlTests.cs
+++ b/test/YesSql.Tests/MySqlTests.cs
@@ -1,7 +1,6 @@
-using System;
-using System.Data.Common;
-using System.Threading.Tasks;
 using MySqlConnector;
+using System;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 using YesSql.Provider.MySql;


### PR DESCRIPTION
Preserve timezone info by using the O format when saving a DateTimeOffset to a varchar column