### PR TITLE
Support long ints

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,10 @@ jobs:
       run: dotnet test --configuration Release --filter YesSql.Tests.MySqlTests --no-restore --no-build --framework net6.0
 
     - name: Test - SQL Server 2019 .NET 6.0
-      run: dotnet test --configuration release --filter yessql.tests.sqlserver2019tests --no-restore --no-build --framework net6.0
+      run: dotnet test --configuration release --filter YesSql.Tests.SqlServer2019Tests --no-restore --no-build --framework net6.0
+
+    - name: Test - PostgresQL Legacy Identity - No Schema
+      run: dotnet test --configuration release --filter YesSql.Tests.PostgreSqlLegacyIdentityTests --no-restore --no-build --framework net6.0
 
     - name: Pack with dotnet
       run: dotnet pack --output artifacts --configuration Release --no-restore --no-build -p:PackageVersion=$GITHUB_RUN_NUMBER

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -76,4 +76,7 @@ jobs:
       run: dotnet test --configuration Release --filter YesSql.Tests.MySqlTests --no-restore --no-build --framework net6.0
 
     - name: Test - SQL Server 2019 .NET 6.0
-      run: dotnet test --configuration release --filter yessql.tests.sqlserver2019tests --no-restore --no-build --framework net6.0
+      run: dotnet test --configuration release --filter YesSql.Tests.SqlServer2019Tests --no-restore --no-build --framework net6.0
+
+    - name: Test - PostgresQL Legacy Identity - No Schema
+      run: dotnet test --configuration release --filter YesSql.Tests.PostgreSqlLegacyIdentityTests --no-restore --no-build --framework net6.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,7 +65,10 @@ jobs:
       run: dotnet test --configuration Release --filter YesSql.Tests.MySqlTests --no-restore --no-build --framework net6.0
 
     - name: Test - SQL Server 2019 .NET 6.0
-      run: dotnet test --configuration Release --filter YesSql.Tests.SqlServer2019Tests --no-restore --no-build --framework net6.0
+      run: dotnet test --configuration release --filter YesSql.Tests.SqlServer2019Tests --no-restore --no-build --framework net6.0
+
+    - name: Test - PostgresQL Legacy Identity - No Schema
+      run: dotnet test --configuration release --filter YesSql.Tests.PostgreSqlLegacyIdentityTests --no-restore --no-build --framework net6.0
 
     - name: Pack
       run: |

--- a/samples/YesSql.Bench/Program.cs
+++ b/samples/YesSql.Bench/Program.cs
@@ -72,7 +72,7 @@ namespace Bench
 
     public class User
     {
-        public int Id { get; set; }
+        public long Id { get; set; }
         public string Name { get; set; }
         public bool Adult { get; set; }
         public int Age { get; set; }

--- a/samples/YesSql.Samples.Web/Models/BlogPost.cs
+++ b/samples/YesSql.Samples.Web/Models/BlogPost.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 
 namespace YesSql.Samples.Web.Models
 {
     public class BlogPost
     {
-        public int Id { get; set; }
+        public long Id { get; set; }
 
         public string Title { get; set; }
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Copyright>Sebastien Ros</Copyright>
         <Authors>Sebastien Ros</Authors>
-        <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <DebugType>portable</DebugType>
         <PackageProjectUrl>https://github.com/sebastienros/yessql</PackageProjectUrl>

--- a/src/YesSql.Abstractions/Commands/ICreateTableCommand.cs
+++ b/src/YesSql.Abstractions/Commands/ICreateTableCommand.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Data;
 
 namespace YesSql.Sql.Schema
 {
@@ -7,5 +6,6 @@ namespace YesSql.Sql.Schema
     {
         ICreateTableCommand Column(string columnName, Type dbType, Action<ICreateColumnCommand> column = null);
         ICreateTableCommand Column<T>(string columnName, Action<ICreateColumnCommand> column = null);
+        public ICreateTableCommand Column(bool useInt64Type, string columnName, Action<ICreateColumnCommand> column = null) => useInt64Type ? Column<int>(columnName, column) : Column<long>(columnName, column);
     }
 }

--- a/src/YesSql.Abstractions/Document.cs
+++ b/src/YesSql.Abstractions/Document.cs
@@ -8,7 +8,7 @@ namespace YesSql
         /// <summary>
         /// The unique identifier of the document in the database.
         /// </summary>
-        public int Id { get; set; }
+        public long Id { get; set; }
 
         /// <summary>
         /// The type of the document.

--- a/src/YesSql.Abstractions/IConfiguration.cs
+++ b/src/YesSql.Abstractions/IConfiguration.cs
@@ -85,6 +85,11 @@ namespace YesSql
         /// Gets or sets the <see cref="ISqlDialect" /> instance.
         /// </summary>
         ISqlDialect SqlDialect { get; set; }
+
+        /// <summary>
+        /// Whether to use legacy Int64 identity columns.
+        /// </summary>
+        bool UseLegacyIdentityColumn { get; set; }
     }
 
     public static class ConfigurationExtensions

--- a/src/YesSql.Abstractions/ISession.cs
+++ b/src/YesSql.Abstractions/ISession.cs
@@ -57,8 +57,6 @@ namespace YesSql
         /// <returns>A collection of objects in the same order they were defined.</returns>
         Task<IEnumerable<T>> GetAsync<T>(long[] ids, string collection = null) where T : class;
 
-        //public Task<IEnumerable<T>> GetAsync<T>(int[] ids, string collection = null) where T : class => GetAsync<T>(ids.Select(x => (long)x).ToArray(), collection);
-
         /// <summary>
         /// Creates a new <see cref="IQuery"/> object.
         /// </summary>
@@ -141,6 +139,12 @@ namespace YesSql
         {
             return (await session.GetAsync<T>(new[] { id }, collection)).FirstOrDefault();
         }
+
+        /// <summary>
+        /// Loads objects by id.
+        /// </summary>
+        /// <returns>A collection of objects in the same order they were defined.</returns>
+        public static Task<IEnumerable<T>> GetAsync<T>(this ISession session, int[] ids, string collection = null) where T : class => session.GetAsync<T>(ids.Select(x => (long)x).ToArray(), collection);
 
         /// <summary>
         /// Imports an object in the local identity map.

--- a/src/YesSql.Abstractions/ISession.cs
+++ b/src/YesSql.Abstractions/ISession.cs
@@ -39,7 +39,7 @@ namespace YesSql
         /// <returns>
         /// <c>true</c> if the object was imported, <c>false</c> otherwise.
         /// </returns>
-        bool Import(object item, int id, int version, string collection = null);
+        bool Import(object item, long id, long version, string collection = null);
 
         /// <summary>
         /// Removes an item from the identity map.
@@ -55,7 +55,9 @@ namespace YesSql
         /// Loads objects by id.
         /// </summary>
         /// <returns>A collection of objects in the same order they were defined.</returns>
-        Task<IEnumerable<T>> GetAsync<T>(int[] ids, string collection = null) where T : class;
+        Task<IEnumerable<T>> GetAsync<T>(long[] ids, string collection = null) where T : class;
+
+        //public Task<IEnumerable<T>> GetAsync<T>(int[] ids, string collection = null) where T : class => GetAsync<T>(ids.Select(x => (long)x).ToArray(), collection);
 
         /// <summary>
         /// Creates a new <see cref="IQuery"/> object.
@@ -135,7 +137,7 @@ namespace YesSql
         /// Loads an object by its id.
         /// </summary>
         /// <returns>The object or <c>null</c>.</returns>
-        public async static Task<T> GetAsync<T>(this ISession session, int id, string collection = null) where T : class
+        public async static Task<T> GetAsync<T>(this ISession session, long id, string collection = null) where T : class
         {
             return (await session.GetAsync<T>(new[] { id }, collection)).FirstOrDefault();
         }

--- a/src/YesSql.Abstractions/ISqlDialect.cs
+++ b/src/YesSql.Abstractions/ISqlDialect.cs
@@ -91,6 +91,11 @@ namespace YesSql
         string IdentityColumnString { get; }
 
         /// <summary>
+        /// Gets the Int64 primary key with identity column SQL statement.
+        /// </summary>
+        string LegacyIdentityColumnString { get; }
+        
+        /// <summary>
         /// Gets the identity select SQL statement to append to an insert in order to return the last generated identifier.
         /// </summary>
         string IdentitySelectString { get; }

--- a/src/YesSql.Abstractions/ISqlDialect.cs
+++ b/src/YesSql.Abstractions/ISqlDialect.cs
@@ -76,11 +76,6 @@ namespace YesSql
         bool PrefixIndex { get; }
 
         /// <summary>
-        /// Return the default database schema name.
-        /// </summary>
-        string DefaultSchema { get; }
-
-        /// <summary>
         /// Gets whether the identity columns requires the data type.
         /// </summary>
         bool HasDataTypeInIdentityColumn { get; }

--- a/src/YesSql.Abstractions/Indexes/IIndex.cs
+++ b/src/YesSql.Abstractions/Indexes/IIndex.cs
@@ -1,10 +1,10 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace YesSql.Indexes
 {
     public interface IIndex
     {
-        int Id { get; set; }
+        long Id { get; set; }
         void AddDocument(Document document);
         void RemoveDocument(Document document);
         IEnumerable<Document> GetAddedDocuments();

--- a/src/YesSql.Abstractions/Indexes/MapIndex.cs
+++ b/src/YesSql.Abstractions/Indexes/MapIndex.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace YesSql.Indexes
 {
@@ -6,7 +6,7 @@ namespace YesSql.Indexes
     {
         private Document Document { get; set; }
 
-        public int Id { get; set; }
+        public long Id { get; set; }
 
         void IIndex.AddDocument(Document document)
         {

--- a/src/YesSql.Abstractions/Indexes/ReduceIndex.cs
+++ b/src/YesSql.Abstractions/Indexes/ReduceIndex.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace YesSql.Indexes
 {
@@ -9,7 +9,7 @@ namespace YesSql.Indexes
             Documents = new List<Document>();
         }
 
-        public int Id { get; set; }
+        public long Id { get; set; }
 
         List<Document> RemovedDocuments = new List<Document>();
 

--- a/src/YesSql.Abstractions/Storage/DocumentIdentity.cs
+++ b/src/YesSql.Abstractions/Storage/DocumentIdentity.cs
@@ -1,24 +1,24 @@
-﻿using System;
+using System;
 
 namespace YesSql.Storage
 {
     public class DocumentIdentity : IIdentityEntity
     {
-        public DocumentIdentity(int id, object entity)
+        public DocumentIdentity(long id, object entity)
         {
             Id = id;
             Entity = entity;
             EntityType = entity.GetType();
         }
 
-        public DocumentIdentity(int id, Type type)
+        public DocumentIdentity(long id, Type type)
         {
             Id = id;
             Entity = null;
             EntityType = type;
         }
 
-        public int Id { get; set; }
+        public long Id { get; set; }
         public object Entity { get; set; }
         public Type EntityType { get; set; }
     }

--- a/src/YesSql.Abstractions/Storage/IIdentityEntity.cs
+++ b/src/YesSql.Abstractions/Storage/IIdentityEntity.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,7 +8,7 @@ namespace YesSql.Storage
 {
     public interface IIdentityEntity
     {
-        int Id { get; set; }
+        long Id { get; set; }
         object Entity { get; set; }
         Type EntityType { get; set; }
     }

--- a/src/YesSql.Abstractions/YesSql.Abstractions.csproj
+++ b/src/YesSql.Abstractions/YesSql.Abstractions.csproj
@@ -1,8 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
-        <PackageReference Include="System.Memory" Version="4.5.0" />
-    </ItemGroup>
     <ItemGroup>
         <!-- Latest minimum LTS version. We don't want to force a higher version to applications -->
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />

--- a/src/YesSql.Core/Commands/CreateIndexCommand.cs
+++ b/src/YesSql.Core/Commands/CreateIndexCommand.cs
@@ -11,13 +11,13 @@ namespace YesSql.Commands
 {
     public sealed class CreateIndexCommand : IndexCommand
     {
-        private readonly int[] _addedDocumentIds;
+        private readonly long[] _addedDocumentIds;
 
         public override int ExecutionOrder { get; } = 2;
 
         public CreateIndexCommand(
             IIndex index,
-            IEnumerable<int> addedDocumentIds,
+            IEnumerable<long> addedDocumentIds,
             IStore store,
             string collection) : base(index, store, collection)
         {
@@ -44,11 +44,11 @@ namespace YesSql.Commands
                 command.CommandText = sql;
                 GetProperties(command, Index, "", dialect);
                 command.AddParameter($"DocumentId", Index.GetAddedDocuments().Single().Id);
-                Index.Id = Convert.ToInt32(await command.ExecuteScalarAsync());
+                Index.Id = Convert.ToInt64(await command.ExecuteScalarAsync());
             }
             else
             {
-                Index.Id = await connection.ExecuteScalarAsync<int>(sql, Index, transaction);
+                Index.Id = await connection.ExecuteScalarAsync<long>(sql, Index, transaction);
 
                 var reduceIndex = Index as ReduceIndex;
                 var bridgeTableName = _store.Configuration.TableNameConvention.GetIndexTable(type, Collection) + "_" + documentTable;
@@ -93,7 +93,7 @@ namespace YesSql.Commands
             actions.Add(dr =>
             {
                 dr.Read();
-                Index.Id = Convert.ToInt32(dr[0]);
+                Index.Id = Convert.ToInt64(dr[0]);
                 dr.NextResult();
             });
 

--- a/src/YesSql.Core/Commands/DeleteDocumentCommand.cs
+++ b/src/YesSql.Core/Commands/DeleteDocumentCommand.cs
@@ -37,7 +37,7 @@ namespace YesSql.Commands
 
             var deleteCmd = $"delete from {dialect.QuoteForTableName(_store.Configuration.TablePrefix + documentTable, _store.Configuration.Schema)} where {dialect.QuoteForColumnName("Id")} = @Id_{index};";
             queries.Add(deleteCmd);
-            command.AddParameter($"Id_{index}", Document.Id, DbType.Int32);
+            command.AddParameter($"Id_{index}", Document.Id);
 
             return true;
         }

--- a/src/YesSql.Core/Commands/DeleteMapIndexCommand.cs
+++ b/src/YesSql.Core/Commands/DeleteMapIndexCommand.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace YesSql.Commands
@@ -12,12 +11,12 @@ namespace YesSql.Commands
     public sealed class DeleteMapIndexCommand : IIndexCommand, ICollectionName
     {
         private readonly IStore _store;
-        public int DocumentId { get; }
+        public long DocumentId { get; }
         public Type IndexType { get; }
         public string Collection { get; }
         public int ExecutionOrder { get; } = 1;
 
-        public DeleteMapIndexCommand(Type indexType, int documentId, IStore store, string collection)
+        public DeleteMapIndexCommand(Type indexType, long documentId, IStore store, string collection)
         {
             IndexType = indexType;
             DocumentId = documentId;
@@ -43,7 +42,7 @@ namespace YesSql.Commands
 
             queries.Add(sql);
 
-            command.AddParameter($"Id_{index}", DocumentId, DbType.Int32);
+            command.AddParameter($"Id_{index}", DocumentId);
 
             return true;
         }

--- a/src/YesSql.Core/Commands/UpdateDocumentCommand.cs
+++ b/src/YesSql.Core/Commands/UpdateDocumentCommand.cs
@@ -72,9 +72,9 @@ namespace YesSql.Commands
             queries.Add(updateCmd);
 
             batchCommand
-                .AddParameter("Id_" + index, Document.Id, DbType.Int32)
-                .AddParameter("Content_" + index, Document.Content, DbType.String)
-                .AddParameter("Version_" + index, Document.Version, DbType.Int64);
+                .AddParameter("Id_" + index, Document.Id)
+                .AddParameter("Content_" + index, Document.Content)
+                .AddParameter("Version_" + index, Document.Version);
 
             return true;
         }

--- a/src/YesSql.Core/Commands/UpdateIndexCommand.cs
+++ b/src/YesSql.Core/Commands/UpdateIndexCommand.cs
@@ -6,21 +6,20 @@ using System.Data.Common;
 using System.Linq;
 using System.Threading.Tasks;
 using YesSql.Indexes;
-using YesSql.Sql.Schema;
 
 namespace YesSql.Commands
 {
     public sealed class UpdateIndexCommand : IndexCommand
     {
-        private readonly int[] _addedDocumentIds;
-        private readonly int[] _deletedDocumentIds;
+        private readonly long[] _addedDocumentIds;
+        private readonly long[] _deletedDocumentIds;
 
         public override int ExecutionOrder { get; } = 3;
 
         public UpdateIndexCommand(
             IIndex index,
-            IEnumerable<int> addedDocumentIds,
-            IEnumerable<int> deletedDocumentIds,
+            IEnumerable<long> addedDocumentIds,
+            IEnumerable<long> deletedDocumentIds,
             IStore _store,
             string collection) : base(index, _store, collection)
         {
@@ -93,7 +92,7 @@ namespace YesSql.Commands
             var parameter = command.CreateParameter();
             parameter.ParameterName = $"Id{index}";
             parameter.Value = Index.Id;
-            parameter.DbType = System.Data.DbType.Int32;
+            parameter.DbType = System.Data.DbType.Int64;
             command.Parameters.Add(parameter);
 
             // Update the documents list
@@ -106,7 +105,7 @@ namespace YesSql.Commands
                 parameter = command.CreateParameter();
                 parameter.ParameterName = $"Id_{index}";
                 parameter.Value = Index.Id;
-                parameter.DbType = System.Data.DbType.Int32;
+                parameter.DbType = System.Data.DbType.Int64;
                 command.Parameters.Add(parameter);
 
                 for (var i = 0; i < _addedDocumentIds.Length; i++)
@@ -117,7 +116,7 @@ namespace YesSql.Commands
                     parameter = command.CreateParameter();
                     parameter.ParameterName = $"AddedId_{index}_{i}";
                     parameter.Value = _addedDocumentIds[i];
-                    parameter.DbType = System.Data.DbType.Int32;
+                    parameter.DbType = System.Data.DbType.Int64;
                     command.Parameters.Add(parameter);
                 }
 
@@ -129,7 +128,7 @@ namespace YesSql.Commands
                     parameter = command.CreateParameter();
                     parameter.ParameterName = $"RemovedId_{index}_{i}";
                     parameter.Value = _deletedDocumentIds[i];
-                    parameter.DbType = System.Data.DbType.Int32;
+                    parameter.DbType = System.Data.DbType.Int64;
                     command.Parameters.Add(parameter);
                 }
             }

--- a/src/YesSql.Core/Configuration.cs
+++ b/src/YesSql.Core/Configuration.cs
@@ -41,5 +41,6 @@ namespace YesSql
         public ITableNameConvention TableNameConvention { get; set; }
         public ICommandInterpreter CommandInterpreter { get; set; }
         public ISqlDialect SqlDialect { get; set; }
+        public bool UseLegacyIdentityColumn { get; set; }
     }
 }

--- a/src/YesSql.Core/ConfigurationExtensions.cs
+++ b/src/YesSql.Core/ConfigurationExtensions.cs
@@ -17,5 +17,12 @@ namespace YesSql
 
             return configuration;
         }
+
+        public static IConfiguration UseLegacyIdentityColumn(this IConfiguration configuration)
+        {
+            configuration.UseLegacyIdentityColumn = true;
+
+            return configuration;
+        }
     }
 }

--- a/src/YesSql.Core/Data/PropertyAccessorFactory.cs
+++ b/src/YesSql.Core/Data/PropertyAccessorFactory.cs
@@ -40,28 +40,75 @@ namespace YesSql.Data
             var getter = propertyInfo.GetGetMethod().CreateDelegate(getType);
             var setter = propertyInfo.GetSetMethod(true).CreateDelegate(setType);
 
-            var accessorType = typeof(IAccessor<,>).MakeGenericType(tContainer, tProperty);
+            Type accessorType = null;
+            
+            if (tProperty == typeof(int))
+            {
+                accessorType = typeof(IntAccessor<>);
+            }
+            else if (tProperty == typeof(long))
+            {
+                accessorType = typeof(LongAccessor<>);
+            }
+
+            if (accessorType == null)
+            {
+                // Id type is not supported
+                return null;
+            }
+
+            accessorType = accessorType.MakeGenericType(tContainer);
 
             return Activator.CreateInstance(accessorType, new object[] { getter, setter }) as IAccessor<T>;
         }
 
-        private class IAccessor<T, TU> : IAccessor<TU>
+        /// <summary>
+        /// An accessor to an Int32 Id property
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        internal class IntAccessor<T> : IAccessor<long>
         {
-            private readonly Func<T, TU> _getter;
-            private readonly Action<T, TU> _setter;
+            private readonly Func<T, int> _getter;
+            private readonly Action<T, int> _setter;
 
-            public IAccessor(Func<T, TU> getter, Action<T, TU> setter)
+            public IntAccessor(Func<T, int> getter, Action<T, int> setter)
             {
                 _getter = getter;
                 _setter = setter;
             }
 
-            TU IAccessor<TU>.Get(object obj)
+            long IAccessor<long>.Get(object obj)
             {
                 return _getter((T)obj);
             }
 
-            void IAccessor<TU>.Set(object obj, TU value)
+            void IAccessor<long>.Set(object obj, long value)
+            {
+                _setter((T)obj, (int)value);
+            }
+        }
+
+        /// <summary>
+        /// An accessor to an Int64 Id property
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        internal class LongAccessor<T> : IAccessor<long>
+        {
+            private readonly Func<T, long> _getter;
+            private readonly Action<T, long> _setter;
+
+            public LongAccessor(Func<T, long> getter, Action<T, long> setter)
+            {
+                _getter = getter;
+                _setter = setter;
+            }
+
+            long IAccessor<long>.Get(object obj)
+            {
+                return _getter((T)obj);
+            }
+
+            void IAccessor<long>.Set(object obj, long value)
             {
                 _setter((T)obj, value);
             }

--- a/src/YesSql.Core/Data/WorkerQueryKey.cs
+++ b/src/YesSql.Core/Data/WorkerQueryKey.cs
@@ -9,11 +9,11 @@ namespace YesSql.Data
     public readonly struct WorkerQueryKey : IEquatable<WorkerQueryKey>
     {
         private readonly string _prefix;
-        private readonly int[] _ids;
+        private readonly long[] _ids;
         private readonly Dictionary<string, object> _parameters;
         private readonly int _hashcode;
 
-        public WorkerQueryKey(string prefix, int[] ids)
+        public WorkerQueryKey(string prefix, long[] ids)
         {
             if (prefix == null)
             {
@@ -101,7 +101,7 @@ namespace YesSql.Data
             {
                 foreach (var id in _ids)
                 {
-                    combinedHash = ((combinedHash << 5) + combinedHash) ^ id;
+                    combinedHash = ((combinedHash << 5) + combinedHash) ^ (int)id;
                 }
 
                 return combinedHash;
@@ -158,7 +158,7 @@ namespace YesSql.Data
             return true;
         }
 
-        private static bool SameIds(int[] values1, int[] values2)
+        private static bool SameIds(long[] values1, long[] values2)
         {
             // If one is not null both need to be non-null
             if (!(values1 != null && values2 != null))

--- a/src/YesSql.Core/Indexes/IdentityMap.cs
+++ b/src/YesSql.Core/Indexes/IdentityMap.cs
@@ -1,19 +1,20 @@
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace YesSql.Indexes
 {
     public class IdentityMap
     {
-        private readonly Dictionary<int, object> _documentIds = new();
-        private readonly Dictionary<object, int> _entities = new();
-        private readonly Dictionary<int, Document> _documents = new();
+        private readonly Dictionary<long, object> _documentIds = new();
+        private readonly Dictionary<object, long> _entities = new();
+        private readonly Dictionary<long, Document> _documents = new();
 
-        public bool TryGetDocumentId(object item, out int id)
+        public bool TryGetDocumentId(object item, out long id)
         {
             return _entities.TryGetValue(item, out id);
         }
 
-        public bool TryGetEntityById(int id, out object document)
+        public bool TryGetEntityById(long id, out object document)
         {
             return _documentIds.TryGetValue(id, out document);
         }
@@ -23,7 +24,7 @@ namespace YesSql.Indexes
             return _entities.ContainsKey(entity);
         }
 
-        public void AddEntity(int id, object entity)
+        public void AddEntity(long id, object entity)
         {
             _entities.Add(entity, id);
             _documentIds.Add(id, entity);
@@ -34,12 +35,12 @@ namespace YesSql.Indexes
             _documents[doc.Id] = doc;
         }
 
-        public bool TryGetDocument(int id, out Document doc)
+        public bool TryGetDocument(long id, out Document doc)
         {
             return _documents.TryGetValue(id, out doc);
         }
 
-        public void Remove(int id, object entity)
+        public void Remove(long id, object entity)
         {
             _entities.Remove(entity);
             _documentIds.Remove(id);

--- a/src/YesSql.Core/Provider/BaseDialect.cs
+++ b/src/YesSql.Core/Provider/BaseDialect.cs
@@ -75,7 +75,7 @@ namespace YesSql.Provider
         public abstract string Name { get; }
         public virtual string InOperator(string values)
         {
-            if (values.StartsWith("@") && !values.Contains(","))
+            if (values.StartsWith("@") && !values.Contains(','))
             {
                 return " IN " + values;
             }
@@ -108,6 +108,7 @@ namespace YesSql.Provider
         public abstract string IdentityLastId { get; }
         
         public abstract string IdentityColumnString { get; }
+        public abstract string LegacyIdentityColumnString { get; }
 
         public virtual string NullColumnString => String.Empty;
 
@@ -224,6 +225,7 @@ namespace YesSql.Provider
                     return Quote(value.ToString());
                 case TypeCode.Boolean:
                     return (bool)value ? "1" : "0";
+                case TypeCode.Byte:
                 case TypeCode.SByte:
                 case TypeCode.Int16:
                 case TypeCode.UInt16:
@@ -237,6 +239,7 @@ namespace YesSql.Provider
                     return Convert.ToString(value, CultureInfo.InvariantCulture);
                 case TypeCode.DateTime:
                     return String.Concat("'", Convert.ToString(value, CultureInfo.InvariantCulture), "'");
+                default: break;
             }
 
             return "null";

--- a/src/YesSql.Core/Provider/BaseDialect.cs
+++ b/src/YesSql.Core/Provider/BaseDialect.cs
@@ -107,7 +107,7 @@ namespace YesSql.Provider
         public abstract string IdentitySelectString { get; }
         public abstract string IdentityLastId { get; }
         
-        public virtual string IdentityColumnString => "[int] IDENTITY(1,1) primary key";
+        public abstract string IdentityColumnString { get; }
 
         public virtual string NullColumnString => String.Empty;
 
@@ -193,8 +193,6 @@ namespace YesSql.Provider
         public virtual string DefaultValuesInsert => "DEFAULT VALUES";
 
         public virtual bool PrefixIndex => false;
-
-        public virtual string DefaultSchema => null;
 
         public abstract byte DefaultDecimalPrecision { get; }
 

--- a/src/YesSql.Core/Services/DbBlockIdGenerator.cs
+++ b/src/YesSql.Core/Services/DbBlockIdGenerator.cs
@@ -69,7 +69,7 @@ namespace YesSql.Services
 
                         localBuilder.CreateTable(DbBlockIdGenerator.TableName, table => table
                             .Column<string>("dimension", column => column.PrimaryKey().NotNull())
-                            .Column<ulong>("nextval")
+                            .Column<long>("nextval")
                             );
 
 #if SUPPORTS_ASYNC_TRANSACTIONS
@@ -141,6 +141,7 @@ namespace YesSql.Services
                         {
                             _store.Configuration.Logger.LogTrace(SelectCommand);
                         }
+
                         nextval = Convert.ToInt64(selectCommand.ExecuteScalar());
 
                         var updateCommand = connection.CreateCommand();

--- a/src/YesSql.Core/Services/DefaultIdGenerator.cs
+++ b/src/YesSql.Core/Services/DefaultIdGenerator.cs
@@ -34,12 +34,7 @@ namespace YesSql.Services
         public Task InitializeAsync(IStore store)
         {
             _dialect = store.Configuration.SqlDialect;
-
-#if NET451
-            return Task.FromResult(0);
-#else
             return Task.CompletedTask;
-#endif
         }
 
         public async Task InitializeCollectionAsync(IConfiguration configuration, string collection)

--- a/src/YesSql.Core/Services/DefaultIdGenerator.cs
+++ b/src/YesSql.Core/Services/DefaultIdGenerator.cs
@@ -46,19 +46,11 @@ namespace YesSql.Services
         {
             // Extract the current max value from the database
 
-#if SUPPORTS_ASYNC_TRANSACTIONS
             await using (var connection = configuration.ConnectionFactory.CreateConnection())
             {
                 await connection.OpenAsync();
 
                 await using (var transaction = connection.BeginTransaction(configuration.IsolationLevel))
-#else
-            using (var connection = configuration.ConnectionFactory.CreateConnection())
-            {
-                await connection.OpenAsync();
-
-                using (var transaction = connection.BeginTransaction(configuration.IsolationLevel))
-#endif
                 {
                     var tableName = configuration.TableNameConvention.GetDocumentTable(collection);
 
@@ -74,11 +66,7 @@ namespace YesSql.Services
                     }
                     var result = await selectCommand.ExecuteScalarAsync();
 
-#if SUPPORTS_ASYNC_TRANSACTIONS
                     await transaction.CommitAsync();
-#else
-                    transaction.Commit();
-#endif
 
                     _seeds[collection] = result == DBNull.Value ? 0 : Convert.ToInt64(result);
                 }

--- a/src/YesSql.Core/Session.cs
+++ b/src/YesSql.Core/Session.cs
@@ -861,11 +861,7 @@ namespace YesSql
             }
             finally
             {
-#if SUPPORTS_ASYNC_TRANSACTIONS
                 await CommitOrRollbackTransactionAsync();
-#else
-                CommitOrRollbackTransaction();
-#endif
             }
         }
 
@@ -895,7 +891,6 @@ namespace YesSql
             }
         }
 
-#if SUPPORTS_ASYNC_TRANSACTIONS
         public async ValueTask DisposeAsync()
         {
             // Do nothing if Dispose() was already called
@@ -981,15 +976,6 @@ namespace YesSql
                 _connection = null;
             }
         }
-
-#else
-        public ValueTask DisposeAsync()
-        {
-            Dispose();
-
-            return default;
-        }
-#endif
 
         /// <summary>
         /// Clears all the resources associated to the transaction.
@@ -1408,12 +1394,7 @@ namespace YesSql
 
             _cancel = true;
 
-#if SUPPORTS_ASYNC_TRANSACTIONS
             return ReleaseTransactionAsync();
-#else
-            ReleaseTransaction();
-            return Task.CompletedTask;
-#endif
         }
 
         public IStore Store => _store;

--- a/src/YesSql.Core/Session.cs
+++ b/src/YesSql.Core/Session.cs
@@ -147,7 +147,7 @@ namespace YesSql
             state.Saved.Add(entity);
         }
 
-        public bool Import(object entity, int id = 0, int version = 0, string collection = null)
+        public bool Import(object entity, long id = 0, long version = 0, string collection = null)
         {
             CheckDisposed();
 
@@ -282,7 +282,7 @@ namespace YesSql
 
             if (versionAccessor != null)
             {
-                versionAccessor.Set(entity, (int) doc.Version);
+                versionAccessor.Set(entity, doc.Version);
             }
 
             doc.Content = Store.Configuration.ContentSerializer.Serialize(entity);
@@ -365,7 +365,7 @@ namespace YesSql
                 // apply the new version to the object
                 if (versionAccessor != null)
                 {
-                    versionAccessor.Set(entity, (int)oldDoc.Version);
+                    versionAccessor.Set(entity, oldDoc.Version);
 
                     newContent = Store.Configuration.ContentSerializer.Serialize(entity);
                 }
@@ -387,7 +387,7 @@ namespace YesSql
             _commands.Add(new UpdateDocumentCommand(oldDoc, Store, version, collection));
         }
 
-        private async Task<Document> GetDocumentByIdAsync(int id, string collection)
+        private async Task<Document> GetDocumentByIdAsync(long id, string collection)
         {
             await CreateConnectionAsync();
 
@@ -476,7 +476,7 @@ namespace YesSql
             }
         }
 
-        public async Task<IEnumerable<T>> GetAsync<T>(int[] ids, string collection = null) where T : class
+        public async Task<IEnumerable<T>> GetAsync<T>(long[] ids, string collection = null) where T : class
         {
             if (ids == null || !ids.Any())
             {
@@ -547,7 +547,7 @@ namespace YesSql
                 {
                     T item;
 
-                    IAccessor<int> accessor;
+                    IAccessor<long> accessor;
                     // If the document type doesn't match the requested one, check it's a base type
                     if (!String.Equals(typeName, d.Type, StringComparison.Ordinal))
                     {
@@ -599,23 +599,13 @@ namespace YesSql
 
             var discriminator = NullableThumbprintFactory.GetNullableThumbprint(compiledQuery);
 
-            if (!_store.CompiledQueries.TryGetValue(discriminator, out var queryState))
+            var queryState = _store.CompiledQueries.GetOrAdd(discriminator, discriminator =>
             {
-                lock (_store.CompiledQueries)
-                {
-                    if (!_store.CompiledQueries.TryGetValue(discriminator, out queryState))
-                    {
-
-                        var localQuery = ((IQuery)new DefaultQuery(this, _tablePrefix, collection)).For<T>(false);
-                        var defaultQuery = (DefaultQuery.Query<T>)compiledQuery.Query().Compile().Invoke(localQuery);
-                        queryState = defaultQuery._query._queryState;
-
-                        _store.CompiledQueries[discriminator] = queryState;
-                    }
-                } 
-            }
-
-            queryState = queryState.Clone();
+                var localQuery = ((IQuery)new DefaultQuery(this, _tablePrefix, collection)).For<T>(false);
+                var defaultQuery = (DefaultQuery.Query<T>)compiledQuery.Query().Compile().Invoke(localQuery);
+                return defaultQuery._query._queryState;
+            })
+            .Clone();
 
             IQuery newQuery = new DefaultQuery(this, queryState, compiledQuery);
             return newQuery.For<T>(false);
@@ -1219,29 +1209,19 @@ namespace YesSql
         /// </summary>
         private Func<IIndex, object> GetGroupingMetod(IndexDescriptor descriptor)
         {
-            if (!_store.GroupMethods.TryGetValue(descriptor.Type, out var result))
+            return _store.GroupMethods.GetOrAdd(descriptor.Type, type =>
             {
-                lock (_store.GroupMethods)
-                {
-                    if (!_store.GroupMethods.TryGetValue(descriptor.Type, out result))
-                    {
-                        // IIndex i => i
-                        var instance = Expression.Parameter(typeof(IIndex), "i");
-                        // i => ((TIndex)i)
-                        var convertInstance = Expression.Convert(instance, descriptor.GroupKey.DeclaringType);
-                        // i => ((TIndex)i).{Property}
-                        var property = Expression.Property(convertInstance, descriptor.GroupKey);
-                        // i => (object)(((TIndex)i).{Property})
-                        var convert = Expression.Convert(property, typeof(object));
+                // IIndex i => i
+                var instance = Expression.Parameter(typeof(IIndex), "i");
+                // i => ((TIndex)i)
+                var convertInstance = Expression.Convert(instance, descriptor.GroupKey.DeclaringType);
+                // i => ((TIndex)i).{Property}
+                var property = Expression.Property(convertInstance, descriptor.GroupKey);
+                // i => (object)(((TIndex)i).{Property})
+                var convert = Expression.Convert(property, typeof(object));
 
-                        result = Expression.Lambda<Func<IIndex, object>>(convert, instance).Compile();
-
-                        _store.GroupMethods[descriptor.Type] = result;
-                    }
-                }
-            }
-
-            return result;
+                return Expression.Lambda<Func<IIndex, object>>(convert, instance).Compile();
+            });
         }
 
         /// <summary>
@@ -1306,11 +1286,11 @@ namespace YesSql
                         {
                             if (index.Id == 0)
                             {
-                                _commands.Add(new CreateIndexCommand(index, Enumerable.Empty<int>(), Store, collection));
+                                _commands.Add(new CreateIndexCommand(index, Enumerable.Empty<long>(), Store, collection));
                             }
                             else
                             {
-                                _commands.Add(new UpdateIndexCommand(index, Enumerable.Empty<int>(), Enumerable.Empty<int>(), Store, collection));
+                                _commands.Add(new UpdateIndexCommand(index, Enumerable.Empty<long>(), Enumerable.Empty<long>(), Store, collection));
                             }
                         }
                         else
@@ -1437,16 +1417,5 @@ namespace YesSql
         }
 
         public IStore Store => _store;
-
-#region Storage implementation
-
-        private struct IdString
-        {
-#pragma warning disable 0649
-            public int Id;
-            public string Content;
-#pragma warning restore 0649
-        }
-#endregion
     }
 }

--- a/src/YesSql.Core/SessionState.cs
+++ b/src/YesSql.Core/SessionState.cs
@@ -25,8 +25,8 @@ namespace YesSql
         public HashSet<object> Tracked => _tracked ??= new HashSet<object>();
 
         // ids of entities that are checked for concurrency
-        internal HashSet<int> _concurrent;
-        public HashSet<int> Concurrent => _concurrent ??= new HashSet<int>();
+        internal HashSet<long> _concurrent;
+        public HashSet<long> Concurrent => _concurrent ??= new HashSet<long>();
 
         // entities that need to be deleted in the next flush
         internal HashSet<object> _deleted;

--- a/src/YesSql.Core/Sql/BaseComandInterpreter.cs
+++ b/src/YesSql.Core/Sql/BaseComandInterpreter.cs
@@ -290,7 +290,7 @@ namespace YesSql.Sql
             // append identity if handled
             if (command.IsIdentity && _dialect.SupportsIdentityColumns)
             {
-                builder.Append(Space).Append(_dialect.IdentityColumnString);
+                builder.Append(Space).Append(_configuration.UseLegacyIdentityColumn ? _dialect.LegacyIdentityColumnString : _dialect.IdentityColumnString);
             }
 
             // [default value]

--- a/src/YesSql.Core/Sql/Schema/CreateTableCommand.cs
+++ b/src/YesSql.Core/Sql/Schema/CreateTableCommand.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Data;
 
 namespace YesSql.Sql.Schema
 {
@@ -25,6 +24,8 @@ namespace YesSql.Sql.Schema
         {
             return Column(columnName, typeof(T), column);
         }
+
+        public ICreateTableCommand Column(bool useInt64Type, string columnName, Action<ICreateColumnCommand> column = null) => useInt64Type ? Column<int>(columnName, column) : Column<long>(columnName, column);
 
     }
 }

--- a/src/YesSql.Core/Sql/SchemaBuilder.cs
+++ b/src/YesSql.Core/Sql/SchemaBuilder.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
-using System.Xml.Linq;
 using YesSql.Sql.Schema;
 
 namespace YesSql.Sql
@@ -19,6 +18,7 @@ namespace YesSql.Sql
         public DbConnection Connection { get; private set; }
         public DbTransaction Transaction { get; private set; }
         public bool ThrowOnError { get; private set; }
+        public bool UseLegacyIdentityColumn { get; set; }
 
         public SchemaBuilder(IConfiguration configuration, DbTransaction transaction, bool throwOnError = true)
         {
@@ -30,6 +30,7 @@ namespace YesSql.Sql
             TablePrefix = configuration.TablePrefix;
             ThrowOnError = throwOnError;
             TableNameConvention = configuration.TableNameConvention;
+            UseLegacyIdentityColumn = configuration.UseLegacyIdentityColumn;
         }
 
         private void Execute(IEnumerable<string> statements)
@@ -63,8 +64,8 @@ namespace YesSql.Sql
                 // NB: Identity() implies PrimaryKey()
 
                 createTable
-                    .Column<long>("Id", column => column.Identity().NotNull())
-                    .Column<long>("DocumentId")
+                    .Column(UseLegacyIdentityColumn, "Id", column => column.Identity().NotNull())
+                    .Column(UseLegacyIdentityColumn, "DocumentId")
                     ;
 
                 table(createTable);
@@ -98,8 +99,7 @@ namespace YesSql.Sql
 
                 // NB: Identity() implies PrimaryKey()
 
-                createTable
-                    .Column<long>("Id", column => column.Identity().NotNull())
+                createTable.Column(UseLegacyIdentityColumn, "Id", column => column.Identity().NotNull())
                     ;
 
                 table(createTable);
@@ -108,8 +108,8 @@ namespace YesSql.Sql
                 var bridgeTableName = indexTable + "_" + documentTable;
 
                 CreateTable(bridgeTableName, bridge => bridge
-                    .Column<long>(indexName + "Id", column => column.NotNull())
-                    .Column<long>("DocumentId", column => column.NotNull())
+                    .Column(UseLegacyIdentityColumn, indexName + "Id", column => column.NotNull())
+                    .Column(UseLegacyIdentityColumn, "DocumentId", column => column.NotNull())
                 );
 
                 CreateForeignKey("FK_" + bridgeTableName + "_Id", bridgeTableName, new[] { indexName + "Id" }, indexTable, new[] { "Id" });

--- a/src/YesSql.Core/Sql/SchemaBuilder.cs
+++ b/src/YesSql.Core/Sql/SchemaBuilder.cs
@@ -63,8 +63,8 @@ namespace YesSql.Sql
                 // NB: Identity() implies PrimaryKey()
 
                 createTable
-                    .Column<int>("Id", column => column.Identity().NotNull())
-                    .Column<int>("DocumentId")
+                    .Column<long>("Id", column => column.Identity().NotNull())
+                    .Column<long>("DocumentId")
                     ;
 
                 table(createTable);
@@ -99,7 +99,7 @@ namespace YesSql.Sql
                 // NB: Identity() implies PrimaryKey()
 
                 createTable
-                    .Column<int>("Id", column => column.Identity().NotNull())
+                    .Column<long>("Id", column => column.Identity().NotNull())
                     ;
 
                 table(createTable);
@@ -108,8 +108,8 @@ namespace YesSql.Sql
                 var bridgeTableName = indexTable + "_" + documentTable;
 
                 CreateTable(bridgeTableName, bridge => bridge
-                    .Column<int>(indexName + "Id", column => column.NotNull())
-                    .Column<int>("DocumentId", column => column.NotNull())
+                    .Column<long>(indexName + "Id", column => column.NotNull())
+                    .Column<long>("DocumentId", column => column.NotNull())
                 );
 
                 CreateForeignKey("FK_" + bridgeTableName + "_Id", bridgeTableName, new[] { indexName + "Id" }, indexTable, new[] { "Id" });

--- a/src/YesSql.Core/Store.cs
+++ b/src/YesSql.Core/Store.cs
@@ -177,7 +177,7 @@ namespace YesSql
                             // The table doesn't exist, create it
                             builder
                                 .CreateTable(documentTable, table => table
-                                .Column<long>(nameof(Document.Id), column => column.PrimaryKey().NotNull())
+                                .Column(Configuration.UseLegacyIdentityColumn, nameof(Document.Id), column => column.PrimaryKey().NotNull())
                                 .Column<string>(nameof(Document.Type), column => column.NotNull())
                                 .Column<string>(nameof(Document.Content), column => column.Unlimited())
                                 .Column<long>(nameof(Document.Version), column => column.NotNull().WithDefault(0))
@@ -314,12 +314,8 @@ namespace YesSql
                 if (!Workers.TryGetValue(key, out var result))
                 {
                     // Multiple threads can potentially reach this point which is fine
-#if !NET451
                     // c.f. https://blogs.msdn.microsoft.com/seteplia/2018/10/01/the-danger-of-taskcompletionsourcet-class/
                     var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-#else
-                    var tcs = new TaskCompletionSource<object>();
-#endif
 
                     Workers.TryAdd(key, tcs.Task);
 

--- a/src/YesSql.Core/YesSql.Core.csproj
+++ b/src/YesSql.Core/YesSql.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
     </PropertyGroup>
@@ -11,11 +11,6 @@
         <PackageReference Include="Dapper.StrongName" Version="2.0.123" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-        <!-- Latest minimum LTS version. We don't want to force a higher version to applications -->
-        <PackageReference Include="System.Buffers" Version="4.5.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/YesSql.Core/YesSql.Core.csproj
+++ b/src/YesSql.Core/YesSql.Core.csproj
@@ -3,10 +3,6 @@
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' or '$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0'">
-        <DefineConstants>$(DefineConstants);SUPPORTS_ASYNC_TRANSACTIONS</DefineConstants>
-    </PropertyGroup>
-
     <ItemGroup>
         <PackageReference Include="Dapper.StrongName" Version="2.0.123" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/src/YesSql.Provider.MySql/MySqlDialect.cs
+++ b/src/YesSql.Provider.MySql/MySqlDialect.cs
@@ -92,7 +92,7 @@ namespace YesSql.Provider.MySql
         public override string Name => "MySql";
         public override string IdentitySelectString => "; select LAST_INSERT_ID()";
         public override string IdentityLastId => "LAST_INSERT_ID()";
-        public override string IdentityColumnString => "int AUTO_INCREMENT primary key";
+        public override string IdentityColumnString => "bigint AUTO_INCREMENT primary key";
         public override string RandomOrderByClause => "rand()";
         public override bool SupportsIfExistsBeforeTableName => true;
 

--- a/src/YesSql.Provider.MySql/MySqlDialect.cs
+++ b/src/YesSql.Provider.MySql/MySqlDialect.cs
@@ -94,6 +94,7 @@ namespace YesSql.Provider.MySql
         public override string IdentitySelectString => "; select LAST_INSERT_ID()";
         public override string IdentityLastId => "LAST_INSERT_ID()";
         public override string IdentityColumnString => "bigint AUTO_INCREMENT primary key";
+        public override string LegacyIdentityColumnString => "int AUTO_INCREMENT primary key";
         public override string RandomOrderByClause => "rand()";
         public override bool SupportsIfExistsBeforeTableName => true;
 

--- a/src/YesSql.Provider.PostgreSql/PostgreSqlDialect.cs
+++ b/src/YesSql.Provider.PostgreSql/PostgreSqlDialect.cs
@@ -110,6 +110,7 @@ namespace YesSql.Provider.PostgreSql
         public override string IdentitySelectString => "RETURNING";
         public override string IdentityLastId => $"lastval()";
         public override string IdentityColumnString => "SERIAL PRIMARY KEY";
+        public override string LegacyIdentityColumnString => "SERIAL PRIMARY KEY";
         public override string RandomOrderByClause => "random()";
         public override bool SupportsIfExistsBeforeTableName => true;
         public override bool PrefixIndex => true;

--- a/src/YesSql.Provider.PostgreSql/PostgreSqlDialect.cs
+++ b/src/YesSql.Provider.PostgreSql/PostgreSqlDialect.cs
@@ -113,8 +113,6 @@ namespace YesSql.Provider.PostgreSql
         public override string RandomOrderByClause => "random()";
         public override bool SupportsIfExistsBeforeTableName => true;
         public override bool PrefixIndex => true;
-        public override string DefaultSchema => "public";
-
         public override string GetTypeName(DbType dbType, int? length, byte? precision, byte? scale)
         {
             if (length.HasValue)
@@ -221,11 +219,10 @@ namespace YesSql.Provider.PostgreSql
 
         public override string QuoteForTableName(string tableName, string schema)
         {
-            return String.IsNullOrEmpty(schema)
+            return string.IsNullOrEmpty(schema)
                 ? $"{QuoteString}{tableName}{QuoteString}"
-                : $"{QuoteString}{schema ?? DefaultSchema}{QuoteString}.{QuoteString}{tableName}{QuoteString}"
+                : $"{QuoteString}{schema}{QuoteString}.{QuoteString}{tableName}{QuoteString}"
                 ;
-
         }
 
         public override string QuoteForAliasName(string aliasName)

--- a/src/YesSql.Provider.SqlServer/SqlServerDialect.cs
+++ b/src/YesSql.Provider.SqlServer/SqlServerDialect.cs
@@ -99,6 +99,7 @@ namespace YesSql.Provider.SqlServer
 
         public override string Name => "SqlServer";
         public override string IdentityColumnString => "[BIGINT] IDENTITY(1,1) primary key";
+        public override string LegacyIdentityColumnString => "[INT] IDENTITY(1,1) primary key";
         public override string IdentitySelectString => "; select SCOPE_IDENTITY()";
         public override string IdentityLastId => "SCOPE_IDENTITY()";
         public override string RandomOrderByClause => "newid()";

--- a/src/YesSql.Provider.SqlServer/SqlServerDialect.cs
+++ b/src/YesSql.Provider.SqlServer/SqlServerDialect.cs
@@ -98,12 +98,12 @@ namespace YesSql.Provider.SqlServer
         }
 
         public override string Name => "SqlServer";
+        public override string IdentityColumnString => "[BIGINT] IDENTITY(1,1) primary key";
         public override string IdentitySelectString => "; select SCOPE_IDENTITY()";
         public override string IdentityLastId => "SCOPE_IDENTITY()";
         public override string RandomOrderByClause => "newid()";
         public override byte DefaultDecimalPrecision => 19;
         public override byte DefaultDecimalScale => 5;
-        public override string DefaultSchema => "dbo";
 
         public override string GetTypeName(DbType dbType, int? length, byte? precision, byte? scale)
         {

--- a/src/YesSql.Provider.Sqlite/SqliteDialect.cs
+++ b/src/YesSql.Provider.Sqlite/SqliteDialect.cs
@@ -96,7 +96,7 @@ namespace YesSql.Provider.Sqlite
         public override string Name => "Sqlite";
 
         public override string IdentityColumnString => "integer primary key autoincrement";
-
+        public override string LegacyIdentityColumnString => "integer primary key autoincrement";
         public override string IdentitySelectString => "; select last_insert_rowid()";
         public override string IdentityLastId => "last_insert_rowid()";
 

--- a/test/YesSql.Tests/CoreTests.cs
+++ b/test/YesSql.Tests/CoreTests.cs
@@ -4687,7 +4687,7 @@ namespace YesSql.Tests
             {
                 var results = await session.Query<Person, PersonByName>().OrderByRandom().ListAsync();
 
-                var idArray = Enumerable.Range(1, 100).Select(x => (long)x).ToArray();
+                var idArray = Enumerable.Range(1, 100).ToArray();
                 Assert.NotEqual(idArray, results.Select(x => x.Id));
             }
         }
@@ -4713,7 +4713,7 @@ namespace YesSql.Tests
 
                 var first50Persons = results.Take(50);
                 Assert.All(first50Persons, person => Assert.Equal("D", person.Firstname));
-                var idArray = Enumerable.Range(1, 50).Select(x => (long)x).ToArray();
+                var idArray = Enumerable.Range(1, 50).ToArray();
                 Assert.NotEqual(idArray, first50Persons.Select(x => x.Id));
             }
         }
@@ -4721,7 +4721,7 @@ namespace YesSql.Tests
         [Fact]
         public async Task ShouldImportDetachedObject()
         {
-            var bill = new PersonWithLongId
+            var bill = new Person
             {
                 Firstname = "Bill",
             };
@@ -4730,7 +4730,7 @@ namespace YesSql.Tests
             {
                 session.Save(bill);
 
-                Assert.Single(await session.Query<PersonWithLongId>().ListAsync());
+                Assert.Single(await session.Query<Person>().ListAsync());
                 Assert.True(bill.Id > 0);
 
                 await session.SaveChangesAsync();
@@ -4738,7 +4738,7 @@ namespace YesSql.Tests
 
             using (var session = _store.CreateSession())
             {
-                bill = new PersonWithLongId
+                bill = new Person
                 {
                     Id = bill.Id,
                     Firstname = "Bill",
@@ -4752,7 +4752,7 @@ namespace YesSql.Tests
 
             using (var session = _store.CreateSession())
             {
-                var all = await session.Query<PersonWithLongId>().ListAsync();
+                var all = await session.Query<Person>().ListAsync();
                 Assert.Single(all);
                 Assert.Equal("Gates", all.First().Lastname);
             }

--- a/test/YesSql.Tests/CoreTests.cs
+++ b/test/YesSql.Tests/CoreTests.cs
@@ -704,7 +704,6 @@ namespace YesSql.Tests
 
             _store.Configuration.Logger = logger;
 
-
             _store.RegisterIndexes<PersonIndexProvider>();
 
             using (var session = _store.CreateSession())
@@ -804,7 +803,7 @@ namespace YesSql.Tests
         [Fact]
         public async Task ShouldSerializeComplexObject()
         {
-            int productId;
+            long productId;
 
             using (var session = _store.CreateSession())
             {
@@ -853,9 +852,9 @@ namespace YesSql.Tests
                     Lastname = "Gates"
                 };
 
-                Assert.True(bill.Id == 0);
+                Assert.Equal(0, bill.Id);
                 session.Save(bill);
-                Assert.True(bill.Id != 0);
+                Assert.NotEqual(0, bill.Id);
 
                 await session.SaveChangesAsync();
             }
@@ -3243,7 +3242,7 @@ namespace YesSql.Tests
         [Fact]
         public async Task ShouldGetTypeById()
         {
-            int circleId;
+            long circleId;
 
             using (var session = _store.CreateSession())
             {
@@ -3272,7 +3271,7 @@ namespace YesSql.Tests
         [Fact]
         public async Task ShouldReturnNullWithWrongTypeById()
         {
-            int circleId;
+            long circleId;
 
             using (var session = _store.CreateSession())
             {
@@ -3300,7 +3299,7 @@ namespace YesSql.Tests
         [Fact]
         public virtual async Task ShouldGetDocumentById()
         {
-            int circleId;
+            long circleId;
 
             using (var session = _store.CreateSession())
             {
@@ -3328,7 +3327,7 @@ namespace YesSql.Tests
         [Fact]
         public async Task ShouldGetObjectById()
         {
-            int circleId;
+            long circleId;
 
             using (var session = _store.CreateSession())
             {
@@ -3357,7 +3356,7 @@ namespace YesSql.Tests
         [Fact]
         public async Task ShouldGetDynamicById()
         {
-            int circleId;
+            long circleId;
 
             using (var session = _store.CreateSession())
             {
@@ -3389,7 +3388,7 @@ namespace YesSql.Tests
         [Theory]
         public async Task ShouldReturnObjectsByIdsInCorrectOrder(int numberOfItems)
         {
-            var circleIds = new List<int>();
+            var circleIds = new List<long>();
 
             using (var session = _store.CreateSession())
             {
@@ -4689,7 +4688,7 @@ namespace YesSql.Tests
             {
                 var results = await session.Query<Person, PersonByName>().OrderByRandom().ListAsync();
 
-                var idArray = Enumerable.Range(1, 100).ToArray();
+                var idArray = Enumerable.Range(1, 100).Select(x => (long)x).ToArray();
                 Assert.NotEqual(idArray, results.Select(x => x.Id));
             }
         }
@@ -4715,7 +4714,7 @@ namespace YesSql.Tests
 
                 var first50Persons = results.Take(50);
                 Assert.All(first50Persons, person => Assert.Equal("D", person.Firstname));
-                var idArray = Enumerable.Range(1, 50).ToArray();
+                var idArray = Enumerable.Range(1, 50).Select(x => (long)x).ToArray();
                 Assert.NotEqual(idArray, first50Persons.Select(x => x.Id));
             }
         }
@@ -4723,17 +4722,16 @@ namespace YesSql.Tests
         [Fact]
         public async Task ShouldImportDetachedObject()
         {
-            var bill = new Person
+            var bill = new PersonWithLongId
             {
                 Firstname = "Bill",
             };
 
             using (var session = _store.CreateSession())
             {
-
                 session.Save(bill);
 
-                Assert.Single(await session.Query<Person>().ListAsync());
+                Assert.Single(await session.Query<PersonWithLongId>().ListAsync());
                 Assert.True(bill.Id > 0);
 
                 await session.SaveChangesAsync();
@@ -4741,7 +4739,7 @@ namespace YesSql.Tests
 
             using (var session = _store.CreateSession())
             {
-                bill = new Person
+                bill = new PersonWithLongId
                 {
                     Id = bill.Id,
                     Firstname = "Bill",
@@ -4755,7 +4753,7 @@ namespace YesSql.Tests
 
             using (var session = _store.CreateSession())
             {
-                var all = await session.Query<Person>().ListAsync();
+                var all = await session.Query<PersonWithLongId>().ListAsync();
                 Assert.Single(all);
                 Assert.Equal("Gates", all.First().Lastname);
             }
@@ -4890,8 +4888,8 @@ namespace YesSql.Tests
         [Fact]
         public async Task ShouldCreateMoreObjectThanIdBlock()
         {
-            var lastId = 0;
-            var firstId = 0;
+            long lastId = 0;
+            long firstId = 0;
 
             using (var session = _store.CreateSession())
             {
@@ -5788,7 +5786,7 @@ namespace YesSql.Tests
                 var connection = await session.CreateConnectionAsync();
                 var transaction = await session.BeginTransactionAsync();
 
-                await new CreateIndexCommand(index, new[] { dummy.Id }, session.Store, "").ExecuteAsync(connection, transaction, session.Store.Configuration.SqlDialect, session.Store.Configuration.Logger);
+                await new CreateIndexCommand(index, new long[] { dummy.Id }, session.Store, "").ExecuteAsync(connection, transaction, session.Store.Configuration.SqlDialect, session.Store.Configuration.Logger);
 
                 await session.SaveChangesAsync();
             }
@@ -5846,7 +5844,7 @@ namespace YesSql.Tests
                 var connection = await session.CreateConnectionAsync();
                 var transaction = await session.BeginTransactionAsync();
 
-                await new CreateIndexCommand(index, new[] { dummy.Id }, session.Store, "").ExecuteAsync(connection, transaction, session.Store.Configuration.SqlDialect, session.Store.Configuration.Logger);
+                await new CreateIndexCommand(index, new long[] { dummy.Id }, session.Store, "").ExecuteAsync(connection, transaction, session.Store.Configuration.SqlDialect, session.Store.Configuration.Logger);
 
                 await session.SaveChangesAsync();
             }
@@ -5910,7 +5908,7 @@ namespace YesSql.Tests
                 var connection = await session.CreateConnectionAsync();
                 var transaction = await session.BeginTransactionAsync();
 
-                await new CreateIndexCommand(index, new[] { dummy.Id }, session.Store, "").ExecuteAsync(connection, transaction, session.Store.Configuration.SqlDialect, session.Store.Configuration.Logger);
+                await new CreateIndexCommand(index, new long[] { dummy.Id }, session.Store, "").ExecuteAsync(connection, transaction, session.Store.Configuration.SqlDialect, session.Store.Configuration.Logger);
 
                 await session.SaveChangesAsync();
             }
@@ -5969,7 +5967,7 @@ namespace YesSql.Tests
                 var connection = await session.CreateConnectionAsync();
                 var transaction = await session.BeginTransactionAsync();
 
-                await new CreateIndexCommand(index, new[] { dummy.Id }, session.Store, "").ExecuteAsync(connection, transaction, session.Store.Configuration.SqlDialect, session.Store.Configuration.Logger);
+                await new CreateIndexCommand(index, new long[] { dummy.Id }, session.Store, "").ExecuteAsync(connection, transaction, session.Store.Configuration.SqlDialect, session.Store.Configuration.Logger);
 
                 await session.SaveChangesAsync();
             }

--- a/test/YesSql.Tests/Models/Article.cs
+++ b/test/YesSql.Tests/Models/Article.cs
@@ -4,7 +4,7 @@ namespace YesSql.Tests.Models
 {
     public class Article
     {
-        public int Id { get; set; }
+        public long Id { get; set; }
         public string Title { get; set; }
         public DateTime PublishedUtc { get; set; }
         public bool IsPublished { get; set; }

--- a/test/YesSql.Tests/Models/Article.cs
+++ b/test/YesSql.Tests/Models/Article.cs
@@ -4,7 +4,7 @@ namespace YesSql.Tests.Models
 {
     public class Article
     {
-        public long Id { get; set; }
+        public int Id { get; set; }
         public string Title { get; set; }
         public DateTime PublishedUtc { get; set; }
         public bool IsPublished { get; set; }

--- a/test/YesSql.Tests/Models/Car.cs
+++ b/test/YesSql.Tests/Models/Car.cs
@@ -2,7 +2,7 @@ namespace YesSql.Tests.Models
 {
     public class Car
     {
-        public long Id { get; set; }
+        public int Id { get; set; }
         public string Name { get; set; }
         public Categories Category { get; set; }
     }

--- a/test/YesSql.Tests/Models/Car.cs
+++ b/test/YesSql.Tests/Models/Car.cs
@@ -2,7 +2,7 @@ namespace YesSql.Tests.Models
 {
     public class Car
     {
-        public int Id { get; set; }
+        public long Id { get; set; }
         public string Name { get; set; }
         public Categories Category { get; set; }
     }

--- a/test/YesSql.Tests/Models/Drawing.cs
+++ b/test/YesSql.Tests/Models/Drawing.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace YesSql.Tests.Models
 {
@@ -14,7 +14,7 @@ namespace YesSql.Tests.Models
 
     public abstract class Shape
     {
-        public int Id { get; set; }
+        public long Id { get; set; }
     }
 
     public class Square : Shape

--- a/test/YesSql.Tests/Models/Email.cs
+++ b/test/YesSql.Tests/Models/Email.cs
@@ -6,7 +6,7 @@ namespace YesSql.Tests.Models
 {
     public class Email
     {
-        public int Id { get; set; }
+        public long Id { get; set; }
         public List<Attachment> Attachments { get; set; }
         public DateTime Date { get; set; }
     }

--- a/test/YesSql.Tests/Models/Email.cs
+++ b/test/YesSql.Tests/Models/Email.cs
@@ -6,7 +6,7 @@ namespace YesSql.Tests.Models
 {
     public class Email
     {
-        public long Id { get; set; }
+        public int Id { get; set; }
         public List<Attachment> Attachments { get; set; }
         public DateTime Date { get; set; }
     }

--- a/test/YesSql.Tests/Models/Person.cs
+++ b/test/YesSql.Tests/Models/Person.cs
@@ -2,7 +2,7 @@ namespace YesSql.Tests.Models
 {
     public class Person
     {
-        public long Id { get; set; }
+        public int Id { get; set; }
         public string Firstname { get; set; }
         public string Lastname { get; set; }
         public int Age { get; set; }

--- a/test/YesSql.Tests/Models/PersonWithLongId.cs
+++ b/test/YesSql.Tests/Models/PersonWithLongId.cs
@@ -1,9 +1,0 @@
-namespace YesSql.Tests.Models
-{
-    public class PersonWithLongId
-    {
-        public long Id { get; set; }
-        public string Firstname { get; set; }
-        public string Lastname { get; set; }
-    }
-}

--- a/test/YesSql.Tests/Models/PersonWithLongId.cs
+++ b/test/YesSql.Tests/Models/PersonWithLongId.cs
@@ -1,12 +1,9 @@
 namespace YesSql.Tests.Models
 {
-    public class Person
+    public class PersonWithLongId
     {
         public long Id { get; set; }
         public string Firstname { get; set; }
         public string Lastname { get; set; }
-        public int Age { get; set; }
-        public bool Anonymous { get; set; }
-        public long Version { get; set; }
     }
 }

--- a/test/YesSql.Tests/Models/Products.cs
+++ b/test/YesSql.Tests/Models/Products.cs
@@ -4,14 +4,14 @@ namespace YesSql.Tests.Models
 {
     public class Product
     {
-        public long Id { get; set; }
+        public int Id { get; set; }
         public string Name { get; set; }
         public decimal Cost { get; set; }
     }
 
     public class Order
     {
-        public long Id { get; set; }
+        public int Id { get; set; }
         public string Customer { get; set; }
         public IList<OrderLine> OrderLines { get; set; }
 
@@ -23,7 +23,7 @@ namespace YesSql.Tests.Models
 
     public class OrderLine
     {
-        public long ProductId { get; set; }
+        public int ProductId { get; set; }
         public int Quantity { get; set; }
     }
 }

--- a/test/YesSql.Tests/Models/Products.cs
+++ b/test/YesSql.Tests/Models/Products.cs
@@ -1,17 +1,17 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace YesSql.Tests.Models
 {
     public class Product
     {
-        public int Id { get; set; }
+        public long Id { get; set; }
         public string Name { get; set; }
         public decimal Cost { get; set; }
     }
 
     public class Order
     {
-        public int Id { get; set; }
+        public long Id { get; set; }
         public string Customer { get; set; }
         public IList<OrderLine> OrderLines { get; set; }
 
@@ -23,7 +23,7 @@ namespace YesSql.Tests.Models
 
     public class OrderLine
     {
-        public int ProductId { get; set; }
+        public long ProductId { get; set; }
         public int Quantity { get; set; }
     }
 }

--- a/test/YesSql.Tests/Models/Tree.cs
+++ b/test/YesSql.Tests/Models/Tree.cs
@@ -6,7 +6,7 @@ namespace YesSql.Tests.Models
 {
     public class Tree
     {
-        public int Id { get; private set; }
+        public long Id { get; private set; }
 
         public string Type { get; set; }
 

--- a/test/YesSql.Tests/PostgreSqlLegacyIdentityTests.cs
+++ b/test/YesSql.Tests/PostgreSqlLegacyIdentityTests.cs
@@ -1,0 +1,32 @@
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using YesSql.Provider.PostgreSql;
+
+namespace YesSql.Tests
+{
+    // Docker command
+    // docker run --name postgresql -e POSTGRES_USER=root -e POSTGRES_PASSWORD=Password12! -e POSTGRES_DB=yessql -d -p 5432:5432 postgres:11
+    public class PostgreSqlLegacyIdentityTests : PostgreSqlTests
+    {
+        public PostgreSqlLegacyIdentityTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override IConfiguration CreateConfiguration()
+        {
+            return new Configuration()
+                .UsePostgreSql(ConnectionStringBuilder.ConnectionString)
+                .SetTablePrefix(TablePrefix)
+                .UseBlockIdGenerator()
+                .UseLegacyIdentityColumn()
+                ;
+        }
+
+        [Fact(Skip = "Skip to make test faster in this configuration")]
+        public override Task ShouldGateQuery()
+        {
+            return base.ShouldGateQuery();
+        }
+    }
+}

--- a/test/YesSql.Tests/SqliteTests.cs
+++ b/test/YesSql.Tests/SqliteTests.cs
@@ -48,11 +48,14 @@ namespace YesSql.Tests
             return base.ShouldReadCommittedRecords();
         }
 
-        //[Fact(Skip = "Breaks other tests if can't finish during delay")]
-        //public override Task ShouldGateQuery()
-        //{
-        //    return base.ShouldGateQuery();
-        //}
+//        [Theory(Skip = "Sqlite doesn't use DbBlockIdGenerator")]
+//        [InlineData(100)]
+//#pragma warning disable xUnit1026 // Theory methods should use all of their parameters
+//        public override Task ShouldGenerateLongIds(long id)
+//#pragma warning restore xUnit1026 // Theory methods should use all of their parameters
+//        {
+//            return Task.CompletedTask;
+//        }
 
         [Fact(Skip = "Sqlite doesn't support concurrent writers")]
         public override Task ShouldReadUncommittedRecords()

--- a/test/YesSql.Tests/WorkerQueryKeyTests.cs
+++ b/test/YesSql.Tests/WorkerQueryKeyTests.cs
@@ -9,8 +9,8 @@ namespace YesSql.Tests
         [Fact]
         public void KeysWithDifferentPrefixShouldNotBeEqual()
         {
-            var key1 = new WorkerQueryKey("prefix1", new[] { 1 });
-            var key2 = new WorkerQueryKey("prefix2", new[] { 1 });
+            var key1 = new WorkerQueryKey("prefix1", new[] { 1L });
+            var key2 = new WorkerQueryKey("prefix2", new[] { 1L });
 
             Assert.False(key1.Equals(key2));
         }
@@ -18,8 +18,8 @@ namespace YesSql.Tests
         [Fact]
         public void KeysWithSamePrefixShouldBeEqual()
         {
-            var key1 = new WorkerQueryKey("prefix1", new[] { 1 });
-            var key2 = new WorkerQueryKey("prefix1", new[] { 1 });
+            var key1 = new WorkerQueryKey("prefix1", new[] { 1L });
+            var key2 = new WorkerQueryKey("prefix1", new[] { 1L });
 
             Assert.True(key1.Equals(key2));
 
@@ -35,8 +35,8 @@ namespace YesSql.Tests
         [Fact]
         public void KeysWithDifferentIdsShouldNotBeEqual()
         {
-            var key1 = new WorkerQueryKey("prefix1", new[] { 1 });
-            var key2 = new WorkerQueryKey("prefix1", new[] { 2 });
+            var key1 = new WorkerQueryKey("prefix1", new[] { 1L });
+            var key2 = new WorkerQueryKey("prefix1", new[] { 2L });
 
             Assert.False(key1.Equals(key2));
         }

--- a/test/YesSql.Tests/YesSql.Tests.csproj
+++ b/test/YesSql.Tests/YesSql.Tests.csproj
@@ -26,10 +26,6 @@
         </PackageReference>
         <PackageReference Include="xunit" Version="2.4.1" />
     </ItemGroup>
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-        <Reference Include="System" />
-        <Reference Include="Microsoft.CSharp" />
-    </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\src\YesSql.Core\YesSql.Core.csproj" />
         <ProjectReference Include="..\..\src\YesSql.Provider.MySql\YesSql.Provider.MySql.csproj" />


### PR DESCRIPTION
Fixes https://github.com/sebastienros/yessql/issues/142 https://github.com/sebastienros/yessql/issues/435 https://github.com/sebastienros/yessql/issues/447

Removes netstandard2.0 support
Sill support `int` in models for backward compatibility
Supports existing databases by using the non-default `UseLegacyIdentityColumn` configuration option
