### PR TITLE
Enumerable filters project

### DIFF
--- a/YesSql.sln
+++ b/YesSql.sln
@@ -50,6 +50,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YesSql.Filters.Abstractions
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YesSql.Filters.Query", "src\YesSql.Filters.Query\YesSql.Filters.Query.csproj", "{86C3967F-B817-4119-B354-B6EB1AC1F237}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YesSql.Filters.Enumerable", "src\YesSql.Filters.Enumerable\YesSql.Filters.Enumerable.csproj", "{8F8F2268-9EE8-4BEC-B60E-44DFC122F6BF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -302,6 +304,22 @@ Global
 		{86C3967F-B817-4119-B354-B6EB1AC1F237}.Release|x64.Build.0 = Release|Any CPU
 		{86C3967F-B817-4119-B354-B6EB1AC1F237}.Release|x86.ActiveCfg = Release|Any CPU
 		{86C3967F-B817-4119-B354-B6EB1AC1F237}.Release|x86.Build.0 = Release|Any CPU
+		{8F8F2268-9EE8-4BEC-B60E-44DFC122F6BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8F8F2268-9EE8-4BEC-B60E-44DFC122F6BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8F8F2268-9EE8-4BEC-B60E-44DFC122F6BF}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{8F8F2268-9EE8-4BEC-B60E-44DFC122F6BF}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{8F8F2268-9EE8-4BEC-B60E-44DFC122F6BF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8F8F2268-9EE8-4BEC-B60E-44DFC122F6BF}.Debug|x64.Build.0 = Debug|Any CPU
+		{8F8F2268-9EE8-4BEC-B60E-44DFC122F6BF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8F8F2268-9EE8-4BEC-B60E-44DFC122F6BF}.Debug|x86.Build.0 = Debug|Any CPU
+		{8F8F2268-9EE8-4BEC-B60E-44DFC122F6BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8F8F2268-9EE8-4BEC-B60E-44DFC122F6BF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8F8F2268-9EE8-4BEC-B60E-44DFC122F6BF}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{8F8F2268-9EE8-4BEC-B60E-44DFC122F6BF}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{8F8F2268-9EE8-4BEC-B60E-44DFC122F6BF}.Release|x64.ActiveCfg = Release|Any CPU
+		{8F8F2268-9EE8-4BEC-B60E-44DFC122F6BF}.Release|x64.Build.0 = Release|Any CPU
+		{8F8F2268-9EE8-4BEC-B60E-44DFC122F6BF}.Release|x86.ActiveCfg = Release|Any CPU
+		{8F8F2268-9EE8-4BEC-B60E-44DFC122F6BF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -322,6 +340,7 @@ Global
 		{6BAC7887-02FB-4B6F-BB5C-D6DEF9646CC6} = {0C294EC4-E6EF-4839-AD34-335C1A5112F9}
 		{348B307C-66F0-4DBE-BA96-5D9DFAB5588E} = {0C294EC4-E6EF-4839-AD34-335C1A5112F9}
 		{86C3967F-B817-4119-B354-B6EB1AC1F237} = {0C294EC4-E6EF-4839-AD34-335C1A5112F9}
+		{8F8F2268-9EE8-4BEC-B60E-44DFC122F6BF} = {0C294EC4-E6EF-4839-AD34-335C1A5112F9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A6AB2945-2138-42B9-8F82-FCCF4DFC8F55}

--- a/src/YesSql.Filters.Enumerable/EnumerableBooleanEngineBuilder.cs
+++ b/src/YesSql.Filters.Enumerable/EnumerableBooleanEngineBuilder.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using YesSql;
+using YesSql.Filters.Abstractions.Builders;
+using YesSql.Filters.Enumerable.Services;
+
+namespace YesSql.Filters.Enumerable
+{
+    public class EnumerableBooleanEngineBuilder<T> : BooleanEngineBuilder<T, EnumerableTermOption<T>> where T : class
+    {
+        public EnumerableBooleanEngineBuilder(
+            string name,
+            Func<string, IEnumerable<T>, EnumerableExecutionContext<T>, ValueTask<IEnumerable<T>>> matchQuery,
+            Func<string, IEnumerable<T>, EnumerableExecutionContext<T>, ValueTask<IEnumerable<T>>> notMatchQuery)
+        {
+            _termOption = new EnumerableTermOption<T>(name, matchQuery, notMatchQuery);
+        }
+    }
+}

--- a/src/YesSql.Filters.Enumerable/EnumerableEngineBuilder.cs
+++ b/src/YesSql.Filters.Enumerable/EnumerableEngineBuilder.cs
@@ -7,11 +7,11 @@ using YesSql.Filters.Enumerable.Services;
 namespace YesSql.Filters.Enumerable
 {
     /// <summary>
-    /// Builds a <see cref="EnumerableEngineBuilder{T}"/> for an <see cref="IQuery{T}"/>.
+    /// Builds a <see cref="EnumerableEngineBuilder{T}"/> for an <see cref="IEnumerable{T}"/>.
     /// </summary>
     public class EnumerableEngineBuilder<T> where T : class
     {
-        private Dictionary<string, TermEngineBuilder<T, EnumerableTermOption<T>>> _termBuilders = new Dictionary<string, TermEngineBuilder<T, EnumerableTermOption<T>>>();
+        private readonly Dictionary<string, TermEngineBuilder<T, EnumerableTermOption<T>>> _termBuilders = new Dictionary<string, TermEngineBuilder<T, EnumerableTermOption<T>>>();
 
         public EnumerableEngineBuilder<T> SetTermParser(TermEngineBuilder<T, EnumerableTermOption<T>> builder)
         {

--- a/src/YesSql.Filters.Enumerable/EnumerableEngineBuilder.cs
+++ b/src/YesSql.Filters.Enumerable/EnumerableEngineBuilder.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using YesSql.Filters.Abstractions.Builders;
+using YesSql.Filters.Enumerable.Services;
+
+namespace YesSql.Filters.Enumerable
+{
+    /// <summary>
+    /// Builds a <see cref="EnumerableEngineBuilder{T}"/> for an <see cref="IQuery{T}"/>.
+    /// </summary>
+    public class EnumerableEngineBuilder<T> where T : class
+    {
+        private Dictionary<string, TermEngineBuilder<T, EnumerableTermOption<T>>> _termBuilders = new Dictionary<string, TermEngineBuilder<T, EnumerableTermOption<T>>>();
+
+        public EnumerableEngineBuilder<T> SetTermParser(TermEngineBuilder<T, EnumerableTermOption<T>> builder)
+        {
+            _termBuilders[builder.Name] = builder;
+
+            return this;
+        }
+
+        public IEnumerableParser<T> Build()
+        {
+            var builders = _termBuilders.Values.Select(x => x.Build());
+
+            var parsers = builders.Select(x => x.Parser).ToArray();
+            var termOptions = builders.Select(x => x.TermOption).ToDictionary(k => k.Name, v => v, StringComparer.OrdinalIgnoreCase);
+
+            return new EnumerableParser<T>(parsers, termOptions);
+        }
+    }
+}

--- a/src/YesSql.Filters.Enumerable/EnumerableEngineBuilderExtensions.cs
+++ b/src/YesSql.Filters.Enumerable/EnumerableEngineBuilderExtensions.cs
@@ -1,0 +1,33 @@
+using System;
+using YesSql.Filters.Abstractions.Builders;
+using YesSql.Filters.Enumerable.Services;
+
+namespace YesSql.Filters.Enumerable
+{
+    public static class EnumerableEngineBuilderExtensions
+    {
+        /// <summary>
+        /// Adds a term where the name must be specified to an <see cref="EnumerableEngineBuilder{T}"/>
+        /// </summary>
+        public static EnumerableEngineBuilder<T> WithNamedTerm<T>(this EnumerableEngineBuilder<T> builder, string name, Action<NamedTermEngineBuilder<T, EnumerableTermOption<T>>> action) where T : class
+        {
+            var parserBuilder = new NamedTermEngineBuilder<T, EnumerableTermOption<T>>(name);
+            action(parserBuilder);
+
+            builder.SetTermParser(parserBuilder);
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds a term where the name is optional to an <see cref="EnumerableEngineBuilder{T}"/>
+        /// </summary>
+        public static EnumerableEngineBuilder<T> WithDefaultTerm<T>(this EnumerableEngineBuilder<T> builder, string name, Action<DefaultTermEngineBuilder<T, EnumerableTermOption<T>>> action) where T : class
+        {
+            var parserBuilder = new DefaultTermEngineBuilder<T, EnumerableTermOption<T>>(name);
+            action(parserBuilder);
+
+            builder.SetTermParser(parserBuilder);
+            return builder;
+        }
+    }
+}

--- a/src/YesSql.Filters.Enumerable/EnumerableFilterResult.cs
+++ b/src/YesSql.Filters.Enumerable/EnumerableFilterResult.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using YesSql.Filters.Abstractions.Nodes;
+using YesSql.Filters.Abstractions.Services;
+using YesSql.Filters.Enumerable.Services;
+
+namespace YesSql.Filters.Enumerable
+{
+    public class EnumerableFilterResult<T> : FilterResult<T, EnumerableTermOption<T>> where T : class
+    {
+        public EnumerableFilterResult(IReadOnlyDictionary<string, EnumerableTermOption<T>> termOptions) : base(termOptions)
+        { }
+
+        public EnumerableFilterResult(List<TermNode> terms, IReadOnlyDictionary<string, EnumerableTermOption<T>> termOptions) : base(terms, termOptions)
+        { }
+
+        public void MapFrom<TModel>(TModel model)
+        {
+            foreach (var option in TermOptions)
+            {
+                if (option.Value.MapFrom is Action<EnumerableFilterResult<T>, string, TermOption, TModel> mappingMethod)
+                {
+                    mappingMethod(this, option.Key, option.Value, model);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Applies term filters to an <see cref="IEnumerable{T}"/>
+        /// </summary>
+        public async ValueTask<IEnumerable<T>> ExecuteAsync(EnumerableExecutionContext<T> context)
+        {
+            var visitor = new EnumerableFilterVisitor<T>();
+
+            foreach (var term in _terms.Values)
+            {
+                // TODO optimize value task.
+                await VisitTerm(TermOptions, context, visitor, term);
+            }
+
+            // Execute always run terms. These are not added to the terms list.
+            foreach (var termOption in TermOptions)
+            {
+                if (!termOption.Value.AlwaysRun)
+                {
+                    continue;
+                }
+
+                if (!_terms.ContainsKey(termOption.Key))
+                {
+                    var alwaysRunNode = new NamedTermNode(termOption.Key, new UnaryNode(String.Empty, OperateNodeQuotes.None));
+                    await VisitTerm(TermOptions, context, visitor, alwaysRunNode);
+                }
+            }
+            
+            return context.Item;
+        }
+
+        private async static Task VisitTerm(IReadOnlyDictionary<string, EnumerableTermOption<T>> termOptions, EnumerableExecutionContext<T> context, EnumerableFilterVisitor<T> visitor, TermNode term)
+        {
+            context.CurrentTermOption = termOptions[term.TermName];
+
+            var termQuery = visitor.Visit(term, context);
+            context.Item = await termQuery.Invoke(context.Item);
+            context.CurrentTermOption = null;
+        }
+    }
+}

--- a/src/YesSql.Filters.Enumerable/EnumerableFilterResultExtensions.cs
+++ b/src/YesSql.Filters.Enumerable/EnumerableFilterResultExtensions.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using YesSql.Filters.Enumerable.Services;
+
+namespace YesSql.Filters.Enumerable
+{
+    public static class EnumerableFilterResultExtensions
+    {
+        public static ValueTask<IEnumerable<T>> ExecuteAsync<T>(this EnumerableFilterResult<T> result, IEnumerable<T> query) where T : class
+            => result.ExecuteAsync(new EnumerableExecutionContext<T>(query));
+    }
+}

--- a/src/YesSql.Filters.Enumerable/EnumerableTermEngineBuilderExtensions.cs
+++ b/src/YesSql.Filters.Enumerable/EnumerableTermEngineBuilderExtensions.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Threading.Tasks;
+using YesSql.Filters.Abstractions.Builders;
+using YesSql.Filters.Enumerable.Services;
+using System.Collections.Generic;
+
+namespace YesSql.Filters.Enumerable
+{
+    public static class QueryTermFilterBuilderExtensions
+    {
+        /// <summary>
+        /// Adds a single condition to a <see cref="TermEngineBuilder{T, TTermOption}"/>.
+        /// <param name="builder"></param>.
+        /// <param name="matchQuery">The predicate to apply when the term is parsed.</param>
+        /// </summary>
+        public static EnumerableUnaryEngineBuilder<T> OneCondition<T>(this TermEngineBuilder<T, EnumerableTermOption<T>> builder, Func<string, IEnumerable<T>, IEnumerable<T>> matchQuery) where T : class
+        {
+            ValueTask<IEnumerable<T>> valueQuery(string q, IEnumerable<T> val, EnumerableExecutionContext<T> ctx) => new(matchQuery(q, val));
+
+            return builder.OneCondition(valueQuery);
+        }
+
+        /// <summary>
+        /// Adds a single condition to a <see cref="TermEngineBuilder{T, TTermOption}"/>.
+        /// <param name="builder"></param>
+        /// <param name="matchQuery">An async predicate to apply when the term is parsed.</param>
+        /// </summary>
+        public static EnumerableUnaryEngineBuilder<T> OneCondition<T>(this TermEngineBuilder<T, EnumerableTermOption<T>> builder, Func<string, IEnumerable<T>, EnumerableExecutionContext<T>, ValueTask<IEnumerable<T>>> matchQuery) where T : class
+        {
+            var operatorBuilder = new EnumerableUnaryEngineBuilder<T>(builder.Name, matchQuery);
+            builder.SetOperator(operatorBuilder);
+
+            return operatorBuilder;
+        }
+
+        /// <summary>
+        /// Adds a condition which supports many operations to a <see cref="TermEngineBuilder{T, TTermOption}"/>
+        /// <param name="builder"></param>
+        /// <param name="matchQuery">The predicate to apply when the term is parsed with an AND or OR operator.</param>
+        /// <param name="notMatchQuery">The predicate to apply when the term is parsed with a NOT operator.</param>
+        /// </summary>
+        public static EnumerableBooleanEngineBuilder<T> ManyCondition<T>(
+            this TermEngineBuilder<T, EnumerableTermOption<T>> builder,
+            Func<string, IEnumerable<T>, IEnumerable<T>> matchQuery,
+            Func<string, IEnumerable<T>, IEnumerable<T>> notMatchQuery) where T : class
+        {
+            ValueTask<IEnumerable<T>> valueMatch(string q, IEnumerable<T> val, EnumerableExecutionContext<T> ctx) => new(matchQuery(q, val));
+            ValueTask<IEnumerable<T>> valueNotMatch(string q, IEnumerable<T> val, EnumerableExecutionContext<T> ctx) => new(notMatchQuery(q, val));
+
+            return builder.ManyCondition(valueMatch, valueNotMatch);
+        }
+
+        /// <summary>
+        /// Adds a condition which supports many operations to a <see cref="TermEngineBuilder{T, TTermOption}"/>
+        /// <param name="builder"></param>.
+        /// <param name="matchQuery">The predicate to apply when the term is parsed with an AND or OR operator.</param>
+        /// <param name="notMatchQuery">The predicate to apply when the term is parsed with a NOT operator.</param>
+        /// </summary>
+        public static EnumerableBooleanEngineBuilder<T> ManyCondition<T>(
+            this TermEngineBuilder<T, EnumerableTermOption<T>> builder,
+            Func<string, IEnumerable<T>, EnumerableExecutionContext<T>, ValueTask<IEnumerable<T>>> matchQuery,
+            Func<string, IEnumerable<T>, EnumerableExecutionContext<T>, ValueTask<IEnumerable<T>>> notMatchQuery) where T : class
+        {
+            var operatorBuilder = new EnumerableBooleanEngineBuilder<T>(builder.Name, matchQuery, notMatchQuery);
+            builder.SetOperator(operatorBuilder);
+
+            return operatorBuilder;
+        }
+    }
+}

--- a/src/YesSql.Filters.Enumerable/EnumerableUnaryEngineBuilder.cs
+++ b/src/YesSql.Filters.Enumerable/EnumerableUnaryEngineBuilder.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Threading.Tasks;
+using YesSql.Filters.Abstractions.Builders;
+using YesSql.Filters.Abstractions.Nodes;
+using YesSql.Filters.Abstractions.Services;
+using YesSql.Filters.Enumerable.Services;
+using YesSql;
+using System.Collections.Generic;
+
+namespace YesSql.Filters.Enumerable
+{
+
+    public class EnumerableUnaryEngineBuilder<T> : UnaryEngineBuilder<T, EnumerableTermOption<T>> where T : class
+    {
+        public EnumerableUnaryEngineBuilder(string name, Func<string, IEnumerable<T>, EnumerableExecutionContext<T>, ValueTask<IEnumerable<T>>> query) : base(new EnumerableTermOption<T>(name, query))
+        {
+        }
+
+        /// <summary>
+        /// Adds a mapping function which can be applied to a model.
+        /// <typeparam name="TModel">The type of model.</typeparam>
+        /// </summary>
+        public EnumerableUnaryEngineBuilder<T> MapTo<TModel>(Action<string, TModel> map)
+        {
+            _termOption.MapTo = map;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a mapping function where terms can be mapped from a model.
+        /// <typeparam name="TModel">The type of model.</typeparam>
+        /// <param name="map">Mapping to apply</param>
+        /// </summary>
+        public EnumerableUnaryEngineBuilder<T> MapFrom<TModel>(Func<TModel, (bool, string)> map)
+        {
+            static TermNode factory(string name, string value) => new NamedTermNode(name, new UnaryNode(value, OperateNodeQuotes.None));
+
+            return MapFrom(map, factory);
+        }
+
+        /// <summary>
+        /// Adds a mapping function where terms can be mapped from a model.
+        /// <typeparam name="TModel">The type of model.</typeparam>
+        /// <param name="map">Mapping to apply</param>
+        /// <param name="factory">Factory to create a <see cref="TermNode" /> when adding a mapping</param>
+        /// </summary>
+        public EnumerableUnaryEngineBuilder<T> MapFrom<TModel>(Func<TModel, (bool, string)> map, Func<string, string, TermNode> factory)
+        {
+            Action<EnumerableFilterResult<T>, string, TermOption, TModel> mapFrom = (EnumerableFilterResult<T> terms, string name, TermOption termOption, TModel model) =>
+            {
+                (var shouldMap, var value) = map(model);
+                if (shouldMap)
+                {
+                    var node = termOption.MapFromFactory(name, value);
+                    terms.TryAddOrReplace(node);
+                }                
+                else
+                {
+                    terms.TryRemove(name);
+                }
+            };
+
+            _termOption.MapFrom = mapFrom;
+            _termOption.MapFromFactory = factory;
+
+            return this;
+        }
+    }
+}

--- a/src/YesSql.Filters.Enumerable/IEnumerableParser.cs
+++ b/src/YesSql.Filters.Enumerable/IEnumerableParser.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using YesSql.Filters.Abstractions.Services;
+
+namespace YesSql.Filters.Enumerable
+{
+    /// <summary>
+    /// Represents a filter parser for an <see cref="IEnumerable{T}"/>
+    /// </summary>
+    public interface IEnumerableParser<T> : IFilterParser<EnumerableFilterResult<T>> where T : class
+    {
+    }
+}

--- a/src/YesSql.Filters.Enumerable/Services/EnumerableExecutionContext.cs
+++ b/src/YesSql.Filters.Enumerable/Services/EnumerableExecutionContext.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using YesSql.Filters.Abstractions.Services;
+
+namespace YesSql.Filters.Enumerable.Services
+{
+    public class EnumerableExecutionContext<T> : FilterExecutionContext<IEnumerable<T>> where T : class
+    {
+        public EnumerableExecutionContext(IEnumerable<T> query) : base(query)
+        {
+        }
+
+        public EnumerableTermOption<T> CurrentTermOption { get; set; }
+    }
+}

--- a/src/YesSql.Filters.Enumerable/Services/EnumerableFilterVisitor.cs
+++ b/src/YesSql.Filters.Enumerable/Services/EnumerableFilterVisitor.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using YesSql.Filters.Abstractions.Nodes;
+using YesSql.Filters.Abstractions.Services;
+
+namespace YesSql.Filters.Enumerable.Services
+{
+    public class EnumerableFilterVisitor<T> : IFilterVisitor<EnumerableExecutionContext<T>, Func<IEnumerable<T>, ValueTask<IEnumerable<T>>>> where T : class
+    {
+        public Func<IEnumerable<T>, ValueTask<IEnumerable<T>>> Visit(TermOperationNode node, EnumerableExecutionContext<T> argument)
+            => node.Operation.Accept(this, argument);
+
+        public Func<IEnumerable<T>, ValueTask<IEnumerable<T>>> Visit(AndTermNode node, EnumerableExecutionContext<T> argument)
+        {
+            var predicates = new List<Func<IEnumerable<T>, ValueTask<IEnumerable<T>>>>();
+            foreach (var child in node.Children)
+            {
+                Func<IEnumerable<T>, ValueTask<IEnumerable<T>>> predicate = (q) => child.Operation.Accept(this, argument)(q);
+                predicates.Add(predicate);
+            }
+
+            var result = (Func<IEnumerable<T>, ValueTask<IEnumerable<T>>>)Delegate.Combine(predicates.ToArray());
+
+            return result;
+        }
+
+        public Func<IEnumerable<T>, ValueTask<IEnumerable<T>>> Visit(UnaryNode node, EnumerableExecutionContext<T> argument)
+        {
+            var currentQuery = argument.CurrentTermOption.MatchPredicate;
+            if (!node.UseMatch)
+            {
+                currentQuery = argument.CurrentTermOption.NotMatchPredicate;
+            }
+
+            return result => currentQuery(node.Value, argument.Item, argument);
+        }
+
+        public Func<IEnumerable<T>, ValueTask<IEnumerable<T>>> Visit(NotUnaryNode node, EnumerableExecutionContext<T> argument)
+        {
+            Func<IEnumerable<T>, ValueTask<IEnumerable<T>>> except = async (q) =>
+            {
+                var not = await node.Operation.Accept(this, argument)(q);
+
+                return not;
+            };
+
+            return except;
+        }
+
+        public Func<IEnumerable<T>, ValueTask<IEnumerable<T>>> Visit(OrNode node, EnumerableExecutionContext<T> argument)
+        {
+            Func<IEnumerable<T>, ValueTask<IEnumerable<T>>> union = async (q) =>
+            {
+                var l = await node.Left.Accept(this, argument)(q);
+                var r = await node.Right.Accept(this, argument)(q);
+
+                return l.Union(r);
+            };
+
+            return union;
+        }
+
+        public Func<IEnumerable<T>, ValueTask<IEnumerable<T>>> Visit(AndNode node, EnumerableExecutionContext<T> argument)
+        {
+            Func<IEnumerable<T>, ValueTask<IEnumerable<T>>> intersect = async (q) =>
+            {
+                var l = await node.Left.Accept(this, argument)(q);
+                var r = await node.Right.Accept(this, argument)(q);
+
+                return l.Intersect(r);
+            };
+
+            return intersect;
+        }
+
+        public Func<IEnumerable<T>, ValueTask<IEnumerable<T>>> Visit(GroupNode node, EnumerableExecutionContext<T> argument)
+            => node.Operation.Accept(this, argument);
+
+        public Func<IEnumerable<T>, ValueTask<IEnumerable<T>>> Visit(TermNode node, EnumerableExecutionContext<T> argument)
+            => node.Accept(this, argument);
+    }
+}

--- a/src/YesSql.Filters.Enumerable/Services/EnumerableParseContext.cs
+++ b/src/YesSql.Filters.Enumerable/Services/EnumerableParseContext.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using Parlot;
+using Parlot.Fluent;
+
+namespace YesSql.Filters.Enumerable.Services
+{
+    public class EnumerableParseContext<T> : ParseContext where T : class
+    {
+        public EnumerableParseContext(IReadOnlyDictionary<string, EnumerableTermOption<T>> termOptions, Scanner scanner, bool useNewLines = false) : base(scanner, useNewLines)
+        {
+            TermOptions = termOptions;
+        }
+
+        public IReadOnlyDictionary<string, EnumerableTermOption<T>> TermOptions { get; }
+    }
+}

--- a/src/YesSql.Filters.Enumerable/Services/EnumerableParser.cs
+++ b/src/YesSql.Filters.Enumerable/Services/EnumerableParser.cs
@@ -1,0 +1,51 @@
+
+using System;
+using System.Collections.Generic;
+using YesSql.Filters.Abstractions.Nodes;
+using Parlot;
+using Parlot.Fluent;
+using static Parlot.Fluent.Parsers;
+
+namespace YesSql.Filters.Enumerable.Services
+{
+    public class EnumerableParser<T> : IEnumerableParser<T> where T : class
+    {
+        private readonly Dictionary<string, EnumerableTermOption<T>> _termOptions;
+        private readonly Parser<EnumerableFilterResult<T>> _parser;
+
+        public EnumerableParser(Parser<TermNode>[] termParsers, Dictionary<string, EnumerableTermOption<T>> termOptions)
+        {
+            _termOptions = termOptions;
+
+            var terms = OneOf(termParsers);
+
+            _parser = ZeroOrMany(terms)
+                    .Then(static (context, terms) =>
+                    {
+                        var ctx = (EnumerableParseContext<T>)context;
+
+                        return new EnumerableFilterResult<T>(terms, ctx.TermOptions);
+                    }).Compile();
+        }
+
+        public EnumerableFilterResult<T> Parse(string text)
+        {
+            if (String.IsNullOrEmpty(text))
+            {
+                return new EnumerableFilterResult<T>(_termOptions);
+            }
+
+            var context = new EnumerableParseContext<T>(_termOptions, new Scanner(text));
+
+            var result = default(ParseResult<EnumerableFilterResult<T>>);
+            if (_parser.Parse(context, ref result))
+            {
+                return result.Value;
+            }
+            else
+            {
+                return new EnumerableFilterResult<T>(_termOptions);
+            }
+        }
+    }
+}

--- a/src/YesSql.Filters.Enumerable/Services/EnumerableTermOption.cs
+++ b/src/YesSql.Filters.Enumerable/Services/EnumerableTermOption.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using YesSql.Filters.Abstractions.Services;
+
+namespace YesSql.Filters.Enumerable.Services
+{
+    public class EnumerableTermOption<T> : TermOption where T : class
+    {
+        public EnumerableTermOption(string name, Func<string, IEnumerable<T>, EnumerableExecutionContext<T>, ValueTask<IEnumerable<T>>> matchPredicate) : base(name)
+        {
+            MatchPredicate = matchPredicate;
+        }
+
+        public EnumerableTermOption(string name, Func<string, IEnumerable<T>, EnumerableExecutionContext<T>, ValueTask<IEnumerable<T>>> matchPredicate, Func<string, IEnumerable<T>, EnumerableExecutionContext<T>, ValueTask<IEnumerable<T>>> notMatchPredicate)
+            : base(name)
+        {
+            MatchPredicate = matchPredicate;
+            NotMatchPredicate = notMatchPredicate;
+        }
+        public Func<string, IEnumerable<T>, EnumerableExecutionContext<T>, ValueTask<IEnumerable<T>>> MatchPredicate { get; }
+        public Func<string, IEnumerable<T>, EnumerableExecutionContext<T>, ValueTask<IEnumerable<T>>> NotMatchPredicate { get; }
+    }
+}

--- a/src/YesSql.Filters.Enumerable/YesSql.Filters.Enumerable.csproj
+++ b/src/YesSql.Filters.Enumerable/YesSql.Filters.Enumerable.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <ItemGroup>
+      <ProjectReference Include="..\YesSql.Filters.Abstractions\YesSql.Filters.Abstractions.csproj" />
+      <ProjectReference Include="..\YesSql.Abstractions\YesSql.Abstractions.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/YesSql.Tests/Filters/EnumerableEngineTests.cs
+++ b/test/YesSql.Tests/Filters/EnumerableEngineTests.cs
@@ -1,0 +1,336 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using YesSql.Filters.Enumerable;
+using YesSql.Tests.Models;
+
+namespace YesSql.Tests.Filters
+{
+    public class EnumerableEngineTests
+    {
+        [Fact]
+        public void ShouldParseNamedTerm()
+        {
+            var parser = new EnumerableEngineBuilder<Person>()
+                .WithNamedTerm("name", b => b.OneCondition(PersonOneConditionQuery()))
+                .Build();
+
+            Assert.Equal("name:steve", parser.Parse("name:steve").ToString());
+            Assert.Equal("name:steve", parser.Parse("name:steve").ToNormalizedString());
+        }
+
+        [Fact]
+        public void ShouldParseNamedTermWhenQuoted()
+        {
+            var parser = new EnumerableEngineBuilder<Person>()
+                .WithNamedTerm("name", b => b.OneCondition(PersonOneConditionQuery()))
+                .Build();
+
+            Assert.Equal("name:\"steve balmer\"", parser.Parse("name:\"steve balmer\"").ToString());
+            Assert.Equal("name:\"steve balmer\"", parser.Parse("name:\"steve balmer\"").ToNormalizedString());
+            Assert.Equal("name:'steve balmer'", parser.Parse("name:'steve balmer'").ToString());
+            Assert.Equal("name:'steve balmer'", parser.Parse("name:'steve balmer'").ToNormalizedString());
+        }
+
+        [Fact]
+        public void ShouldParseTermWithLocalizedChars()
+        {
+            var parser = new EnumerableEngineBuilder<Person>()
+                .WithNamedTerm("name", b => b.OneCondition(PersonOneConditionQuery()))
+                .Build();
+
+            Assert.Equal("name:账单", parser.Parse("name:账单").ToString());
+            Assert.Equal("name:账单", parser.Parse("name:账单").ToNormalizedString());
+        }        
+
+        [Fact]
+        public void ShouldParseManyNamedTerms()
+        {
+            var parser = new EnumerableEngineBuilder<Person>()
+                .WithNamedTerm("name", b => b.OneCondition(PersonOneConditionQuery()))
+                .WithNamedTerm("status", b => b.OneCondition(PersonOneConditionQuery()))
+                .Build();
+
+            Assert.Equal("name:steve status:published", parser.Parse("name:steve status:published").ToString());
+            Assert.Equal("name:steve status:published", parser.Parse("name:steve status:published").ToNormalizedString());
+        }
+
+        [Fact]
+        public void ShouldParseManyNamedTermsWithManyCondition()
+        {
+            var parser = new EnumerableEngineBuilder<Person>()
+                .WithNamedTerm("name", b => b
+                    .ManyCondition(PersonManyMatch(), PersonManyNotMatch()))
+                .WithNamedTerm("status", b => b
+                    .ManyCondition(PersonManyMatch(), PersonManyNotMatch()))
+                .Build();
+
+            Assert.Equal("name:steve status:published", parser.Parse("name:steve status:published").ToString());
+            Assert.Equal("name:steve status:published", parser.Parse("name:steve status:published").ToNormalizedString());
+        }
+
+        [Fact]
+        public void ShouldParseDefaultTermWithManyCondition()
+        {
+            var parser = new EnumerableEngineBuilder<Person>()
+                .WithDefaultTerm("name", b => b.ManyCondition(PersonManyMatch(), PersonManyNotMatch()))
+                .WithNamedTerm("status", b => b.ManyCondition(PersonManyMatch(), PersonManyNotMatch()))
+                .Build();
+
+            Assert.Equal("steve status:published", parser.Parse("steve status:published").ToString());
+            Assert.Equal("name:steve status:published", parser.Parse("steve status:published").ToNormalizedString());
+        }
+
+        [Fact]
+        public void ShouldParseDefaultTermWithManyConditionWhenLast()
+        {
+            var parser = new EnumerableEngineBuilder<Person>()
+                .WithNamedTerm("status", b => b.ManyCondition(PersonManyMatch(), PersonManyNotMatch()))
+                .WithDefaultTerm("name", b => b.ManyCondition(PersonManyMatch(), PersonManyNotMatch()))
+                .Build();
+
+            Assert.Equal("steve status:published", parser.Parse("steve status:published").ToString());
+            Assert.Equal("name:steve status:published", parser.Parse("steve status:published").ToNormalizedString());
+        }
+
+        [Fact]
+        public void ShouldParseDefaultTermWithManyConditionWhenDefaultIsFirst()
+        {
+            // TODO Validation on builder if you have two manys. you cannot have a default.
+            var parser = new EnumerableEngineBuilder<Person>()
+                .WithDefaultTerm("name", b => b.ManyCondition(PersonManyMatch(), PersonManyNotMatch()))
+                .WithNamedTerm("status", b => b.ManyCondition(PersonManyMatch(), PersonManyNotMatch()))
+                .Build();
+
+            Assert.Equal("status:(published OR steve)", parser.Parse("status:published steve").ToNormalizedString());
+        }
+
+        [Fact]
+        public void ShouldParseDefaultTerm()
+        {
+            var parser = new EnumerableEngineBuilder<Person>()
+                .WithNamedTerm("age", b => b.OneCondition(PersonOneConditionQuery()))
+                .WithDefaultTerm("name", b => b.OneCondition(PersonOneConditionQuery()))
+                .Build();
+
+            Assert.Equal("name:steve", parser.Parse("name:steve").ToString());
+            Assert.Equal("steve", parser.Parse("steve").ToString());
+            Assert.Equal("steve age:20", parser.Parse("steve age:20").ToString());
+            Assert.Equal("age:20 name:steve", parser.Parse("age:20 name:steve").ToString());
+            Assert.Equal("age:20 steve", parser.Parse("age:20 steve").ToString());
+            Assert.Equal(2, parser.Parse("steve age:20").Count());
+            Assert.Equal("name:steve", parser.Parse("steve").ToNormalizedString());
+        }
+
+        [Fact]
+        public void ShouldParseDefaultTermWithOneMany()
+        {
+            var parser = new EnumerableEngineBuilder<Person>()
+                .WithNamedTerm("age", builder => builder.OneCondition(PersonOneConditionQuery()))
+                .WithDefaultTerm("name", builder =>
+                    builder.ManyCondition(PersonManyMatch(), PersonManyNotMatch())
+                )
+                .Build();
+
+
+            Assert.Equal("name:steve", parser.Parse("name:steve").ToString());
+            Assert.Equal("steve", parser.Parse("steve").ToString());
+            Assert.Equal("steve age:20", parser.Parse("steve age:20").ToString());
+            Assert.Equal("age:20 name:steve", parser.Parse("age:20 name:steve").ToString());
+            Assert.Equal("age:20 steve", parser.Parse("age:20 steve").ToString());
+            Assert.Equal(2, parser.Parse("steve age:20").Count());
+            Assert.Equal("name:steve", parser.Parse("steve").ToNormalizedString());
+        }
+
+        [Fact]
+        public void ShouldParseDefaultTermAtEndOfStatement()
+        {
+            var parser = new EnumerableEngineBuilder<Person>()
+                .WithNamedTerm("age", b => b
+                    .OneCondition((val, query) =>
+                    {
+                        if (Int32.TryParse(val, out var age))
+                        {
+                            query.Where(x => x.Age == age);
+                        }
+
+                        return query;
+                    }))
+                .WithDefaultTerm("name", b => b.OneCondition(PersonOneConditionQuery()))
+                .Build();
+
+
+            Assert.Equal("age:20 name:steve", parser.Parse("age:20 name:steve").ToString());
+            Assert.Equal(2, parser.Parse("age:20 name:steve").Count());
+            Assert.Equal("age:20 steve", parser.Parse("age:20 steve").ToString());
+            Assert.Equal(2, parser.Parse("age:20 steve").Count());
+        }
+
+        [Fact]
+        public void ShouldParseDefaultTermAtEndOfStatementWithBuilder()
+        {
+            var parser = new EnumerableEngineBuilder<Person>()
+                .WithNamedTerm("age", builder =>
+                    builder
+                        .OneCondition((val, query) =>
+                        {
+                            if (Int32.TryParse(val, out var age))
+                            {
+                                query.Where(x => x.Age == age);
+                            }
+
+                            return query;
+                        })
+                )
+                .WithDefaultTerm("name", builder =>
+                    builder.OneCondition(PersonOneConditionQuery())
+                )
+                .Build();
+
+            Assert.Equal("age:20 name:steve", parser.Parse("age:20 name:steve").ToString());
+            Assert.Equal(2, parser.Parse("age:20 name:steve").Count());
+            Assert.Equal("age:20 steve", parser.Parse("age:20 steve").ToString());
+            Assert.Equal(2, parser.Parse("age:20 steve").Count());
+        }
+
+        [Fact]
+        public void OrderOfDefaultTermShouldNotMatter()
+        {
+            var parser1 = new EnumerableEngineBuilder<Person>()
+                .WithNamedTerm("age", b => b.OneCondition(PersonOneConditionQuery()))
+                .WithDefaultTerm("name", b => b.ManyCondition(PersonManyMatch(), PersonManyNotMatch()))
+                .Build();
+
+            var parser2 = new EnumerableEngineBuilder<Person>()
+                .WithDefaultTerm("name", b => b.ManyCondition(PersonManyMatch(), PersonManyNotMatch()))
+                .WithNamedTerm("age", b => b.OneCondition(PersonOneConditionQuery()))
+                .Build();
+
+            Assert.Equal("steve age:20", parser1.Parse("steve age:20").ToString());
+
+            var result = parser1.Parse("steve age:20");
+            Assert.Equal(2, result.Count());
+
+            Assert.Equal("age:20 steve", parser1.Parse("age:20 steve").ToString());
+            Assert.Equal(2, parser1.Parse("age:20 steve").Count());
+
+            Assert.Equal("steve age:20", parser2.Parse("steve age:20").ToString());
+            Assert.Equal(2, parser2.Parse("steve age:20").Count());
+
+            Assert.Equal("age:20 steve", parser2.Parse("age:20 steve").ToString());
+            Assert.Equal(2, parser2.Parse("age:20 steve").Count());
+        }
+
+        [Theory]
+        [InlineData("title:bill post", "title:(bill OR post)")]
+        [InlineData("title:bill OR post", "title:(bill OR post)")]
+        [InlineData("title:beach AND sand", "title:(beach AND sand)")]
+        [InlineData("title:beach AND sand OR mountain AND lake", "title:((beach AND sand) OR (mountain AND lake))")]
+        [InlineData("title:(beach AND sand) OR (mountain AND lake)", "title:((beach AND sand) OR (mountain AND lake))")]
+        [InlineData("title:(beach AND sand) OR (mountain AND lake) NOT lizards", "title:(((beach AND sand) OR (mountain AND lake)) NOT lizards)")]
+        [InlineData("title:NOT beach", "title:NOT beach")]
+        [InlineData("title:beach NOT mountain", "title:(beach NOT mountain)")]
+        [InlineData("title:beach NOT mountain lake", "title:((beach NOT mountain) OR lake)")]
+        public void Complex(string search, string normalized)
+        {
+            var parser = new EnumerableEngineBuilder<Article>()
+                .WithNamedTerm("title", b => b.ManyCondition(ArticleManyMatch(), ArticleManyNotMatch()))
+                .Build();
+
+            var result = parser.Parse(search);
+
+            Assert.Equal(normalized, result.ToNormalizedString());
+        }
+
+        [Theory]
+        [InlineData("title:(bill)", "title:(bill)")]
+        [InlineData("title:(bill AND steve) OR Paul", "title:((bill AND steve) OR Paul)")]
+        [InlineData("title:((bill AND steve) OR Paul)", "title:((bill AND steve) OR Paul)")]
+        public void ShouldGroup(string search, string normalized)
+        {
+            var parser = new EnumerableEngineBuilder<Article>()
+                .WithNamedTerm("title", b => b.ManyCondition(ArticleManyMatch(), ArticleManyNotMatch()))
+                .Build();
+
+            var result = parser.Parse(search);
+
+            Assert.Equal(search, result.ToString());
+            Assert.Equal(normalized, result.ToNormalizedString());
+        }
+
+        [Theory]
+        [InlineData("title:bill steve")]
+        public void ShouldNotIncludeExtraWhitespace(string search)
+        {
+            var parser = new EnumerableEngineBuilder<Article>()
+                .WithNamedTerm("title", b => b.ManyCondition(ArticleManyMatch(), ArticleManyNotMatch()))
+                .Build();
+
+            var result = parser.Parse(search);
+
+            Assert.Equal(search, result.ToString());
+        }
+
+        [Fact]
+        public void ShouldIgnoreMultipleNamedTerms()
+        {
+            var parser = new EnumerableEngineBuilder<Person>()
+                .WithNamedTerm("name", b => b.OneCondition(PersonOneConditionQuery()))
+                .Build();
+
+            // By convention the last term is used when single = true;
+            Assert.Equal("name:bill", parser.Parse("name:steve name:bill").ToString());
+            Assert.Equal("name:bill", parser.Parse("name:steve name:bill").ToNormalizedString());
+        }
+
+        [Fact]
+        public void ShouldAllowMultipleNamedTerms()
+        {
+            var parser = new EnumerableEngineBuilder<Person>()
+                .WithNamedTerm("name", b => b
+                    .OneCondition(PersonOneConditionQuery())
+                    .AllowMultiple())
+                .Build();
+
+            // By convention the last term is used when single = true;
+            Assert.Equal("name:steve name:bill", parser.Parse("name:steve name:bill").ToString());
+            Assert.Equal("name:steve name:bill", parser.Parse("name:steve name:bill").ToNormalizedString());
+        }
+
+        [Theory]
+        [InlineData("extrachar:age-asc")]
+        [InlineData("extrachar:age-desc")]
+        [InlineData("extrachar:2020-01-01..2020-10-10")]
+        [InlineData("extrachar:>ten")]
+        [InlineData("extrachar:<100")]
+        [InlineData("extrachar:<=100")]
+        [InlineData("extrachar:100*")]
+        [InlineData("extrachar:100+")]
+        public void ShouldIncludeExtraChars(string search)
+        {
+            var parser = new EnumerableEngineBuilder<Person>()
+                .WithNamedTerm("extrachar", b => b.OneCondition(PersonOneConditionQuery()))
+                .Build();
+
+            var result = parser.Parse(search);
+
+            Assert.Equal(search, result.ToString());
+        } 
+
+        private static Func<string, IEnumerable<Person>, IEnumerable<Person>> PersonOneConditionQuery()
+            => (val, enumerable) => enumerable.Where(x => x.Firstname.Contains(val, StringComparison.OrdinalIgnoreCase));
+
+        private static Func<string, IEnumerable<Person>, IEnumerable<Person>> PersonManyMatch()
+            => PersonOneConditionQuery();
+
+        private static Func<string, IEnumerable<Person>, IEnumerable<Person>> PersonManyNotMatch()
+            => (val, query) => query.Where(x => !x.Firstname.Contains(val, StringComparison.OrdinalIgnoreCase));
+
+        private static Func<string, IEnumerable<Article>, IEnumerable<Article>> ArticleManyMatch()
+            => (val, query) => query.Where(x => x.Title.Contains(val, StringComparison.OrdinalIgnoreCase));
+
+        private static Func<string, IEnumerable<Article>, IEnumerable<Article>> ArticleManyNotMatch()
+            => (val, query) => query.Where(x => !x.Title.Contains(val, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/test/YesSql.Tests/Filters/EnumerableEngineTests.cs
+++ b/test/YesSql.Tests/Filters/EnumerableEngineTests.cs
@@ -152,7 +152,7 @@ namespace YesSql.Tests.Filters
                     {
                         if (Int32.TryParse(val, out var age))
                         {
-                            query.Where(x => x.Age == age);
+                            query = query.Where(x => x.Age == age);
                         }
 
                         return query;
@@ -177,7 +177,7 @@ namespace YesSql.Tests.Filters
                         {
                             if (Int32.TryParse(val, out var age))
                             {
-                                query.Where(x => x.Age == age);
+                                query = query.Where(x => x.Age == age);
                             }
 
                             return query;

--- a/test/YesSql.Tests/Filters/EnumerableFilterTests.cs
+++ b/test/YesSql.Tests/Filters/EnumerableFilterTests.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 using YesSql.Filters.Enumerable;
-using YesSql.Tests.Indexes;
 using YesSql.Tests.Models;
 
 namespace YesSql.Tests.Filters

--- a/test/YesSql.Tests/Filters/EnumerableFilterTests.cs
+++ b/test/YesSql.Tests/Filters/EnumerableFilterTests.cs
@@ -1,0 +1,407 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using YesSql.Filters.Enumerable;
+using YesSql.Tests.Indexes;
+using YesSql.Tests.Models;
+
+namespace YesSql.Tests.Filters
+{
+    public class ArticleDocument
+    {
+        public List<Article> Articles { get; } = new();
+    }
+
+    public class EnumerableFilterTests
+    {
+        [Fact]
+        public async Task ShouldParseNamedTermQuery()
+        {
+            var document = new ArticleDocument();
+            var billsArticle = new Article
+            {
+                Title = "article by bill about rabbits",
+                PublishedUtc = DateTime.UtcNow
+            };
+
+            var stevesArticle = new Article
+            {
+                Title = "post by steve about cats",
+                PublishedUtc = DateTime.UtcNow
+            };
+
+            document.Articles.Add(billsArticle);
+            document.Articles.Add(stevesArticle);
+
+
+            var filter = "title:steve";
+
+            var toFilter = document.Articles.AsEnumerable();
+
+            var parser = new EnumerableEngineBuilder<Article>()
+                .WithNamedTerm("title", b => b
+                    .OneCondition((val, enumerable) => enumerable.Where(x => x.Title.Contains(val, StringComparison.OrdinalIgnoreCase)))
+                )
+                .Build();
+
+            var parsed = parser.Parse(filter);
+
+            var filtered = await parsed.ExecuteAsync(toFilter);
+
+            // Parsed query
+            Assert.Equal("post by steve about cats", filtered.FirstOrDefault().Title);
+            Assert.Single(filtered);
+        }
+
+        [Theory]
+        [InlineData("steve")]
+        [InlineData("title:steve")]
+        public async Task ShouldParseDefaultTermQuery(string search)
+        {
+            var document = new ArticleDocument();
+
+            var billsArticle = new Article
+            {
+                Title = "article by bill about rabbits",
+                PublishedUtc = DateTime.UtcNow
+            };
+
+            var stevesArticle = new Article
+            {
+                Title = "post by steve about cats",
+                PublishedUtc = DateTime.UtcNow
+            };
+
+            document.Articles.Add(billsArticle);
+            document.Articles.Add(stevesArticle);
+
+            var toQuery = document.Articles.AsEnumerable();
+
+            var parser = new EnumerableEngineBuilder<Article>()
+                .WithDefaultTerm("title", b => b
+                    .OneCondition((val, query) => query.Where(x => x.Title.Contains(val, StringComparison.OrdinalIgnoreCase))))
+                .Build();
+
+            var parsed = parser.Parse(search);
+
+            var filtered = await parsed.ExecuteAsync(toQuery);
+
+            var assert3 = filtered.FirstOrDefault().Title;
+            var assert4 = filtered.Count();
+
+            // Parsed query
+            Assert.Equal("post by steve about cats", assert3);
+            Assert.Equal(1, assert4);
+        }
+
+        [Fact]
+        public async Task ShouldParseOrQuery()
+        {
+            var document = new ArticleDocument();
+
+            var billsArticle = new Article
+            {
+                Title = "article by bill about rabbits",
+                PublishedUtc = DateTime.UtcNow
+            };
+
+            var stevesArticle = new Article
+            {
+                Title = "post by steve about cats",
+                PublishedUtc = DateTime.UtcNow
+            };
+
+            document.Articles.Add(billsArticle);
+            document.Articles.Add(stevesArticle);
+
+            // boolean OR "title:(bill OR post)"
+            var filter = "title:bill post";
+            var filterQuery = document.Articles.AsEnumerable();
+
+            var parser = new EnumerableEngineBuilder<Article>()
+                .WithNamedTerm("title", b => b
+                    .ManyCondition(
+                        (val, query) => query.Where(x => x.Title.Contains(val, StringComparison.OrdinalIgnoreCase)),
+                        (val, query) => query.Where(x => !x.Title.Contains(val, StringComparison.OrdinalIgnoreCase))
+                    )
+                )
+                .Build();
+
+            var parsed = parser.Parse(filter);
+            var filtered = await parsed.ExecuteAsync(filterQuery);
+
+            // Parsed query
+            Assert.Equal(2, filtered.Count());
+        }
+
+        [Fact]
+        public async Task ShouldParseAndQuery()
+        {
+            var document = new ArticleDocument();
+
+            var billsArticle = new Article
+            {
+                Title = "article by bill about rabbits",
+                PublishedUtc = DateTime.UtcNow
+            };
+
+            var stevesArticle = new Article
+            {
+                Title = "post by steve about cats",
+                PublishedUtc = DateTime.UtcNow
+            };
+
+            document.Articles.Add(billsArticle);
+            document.Articles.Add(stevesArticle);
+
+            var toFilter = document.Articles.AsEnumerable();
+
+            // boolean AND "title:(bill AND rabbits)"
+            var filter = "title:bill AND rabbits";
+
+            var parser = new EnumerableEngineBuilder<Article>()
+                .WithNamedTerm("title", b => b
+                    .ManyCondition(
+                        (val, query) => query.Where(x => x.Title.Contains(val, StringComparison.OrdinalIgnoreCase)),
+                        (val, query) => query.Where(x => !x.Title.Contains(val, StringComparison.OrdinalIgnoreCase))
+                    )
+                )
+                .Build();
+
+            var parsed = parser.Parse(filter);
+
+            var filtered = await parsed.ExecuteAsync(toFilter);
+
+            // Parsed query
+            Assert.Single(filtered);
+        }
+
+        [Fact]
+        public async Task ShouldParseTwoNamedTermQuerys()
+        {
+            var document = new ArticleDocument();
+
+            var billsArticle = new Article
+            {
+                Title = "article by bill about rabbits",
+                PublishedUtc = DateTime.UtcNow
+            };
+
+            var stevesArticle = new Article
+            {
+                Title = "article by steve about cats",
+                PublishedUtc = DateTime.UtcNow
+            };
+
+            document.Articles.Add(billsArticle);
+            document.Articles.Add(stevesArticle);
+
+            var filter = "title:article title:article";
+            var filterQuery = document.Articles.AsEnumerable();
+
+            var parser = new EnumerableEngineBuilder<Article>()
+                .WithNamedTerm("title", b => b
+                    .OneCondition((val, query) => query.Where(x => x.Title.Contains(val, StringComparison.OrdinalIgnoreCase)))
+                    .AllowMultiple()
+                )
+                .Build();
+
+            var parsed = parser.Parse(filter);
+
+            var filtered = await parsed.ExecuteAsync(filterQuery);
+
+            // Parsed query
+            Assert.Equal(2, filterQuery.Count());
+        }
+
+        [Fact]
+        public async Task ShouldParseComplexQuery()
+        {
+            var document = new ArticleDocument();
+            var beachLizardsArticle = new Article
+            {
+                Title = "On the beach in the sand we found lizards",
+                PublishedUtc = DateTime.UtcNow
+            };
+
+            var mountainArticle = new Article
+            {
+                Title = "On the mountain it snowed at the lake",
+                PublishedUtc = DateTime.UtcNow
+            };
+
+            document.Articles.Add(beachLizardsArticle);
+            document.Articles.Add(mountainArticle);
+
+
+            var filter = "title:(beach AND sand) OR (mountain AND lake)";
+            var filterQuery = document.Articles.AsEnumerable();
+
+            var parser = new EnumerableEngineBuilder<Article>()
+                .WithNamedTerm("title", b => b
+                    .ManyCondition(
+                        (val, query) => query.Where(x => x.Title.Contains(val, StringComparison.OrdinalIgnoreCase)),
+                        (val, query) => query.Where(x => !x.Title.Contains(val, StringComparison.OrdinalIgnoreCase))
+                    )
+                )
+                .Build();
+
+            var parsed = parser.Parse(filter);
+
+            await parsed.ExecuteAsync(filterQuery);
+
+            // Parsed query
+            Assert.Equal(2, filterQuery.Count());
+        }
+
+        [Fact]
+        public async Task ShouldParseNotComplexQuery()
+        {
+            var document = new ArticleDocument();
+
+            var beachLizardsArticle = new Article
+            {
+                Title = "On the beach in the sand we found lizards",
+                PublishedUtc = DateTime.UtcNow
+            };
+
+            var sandcastlesArticle = new Article
+            {
+                Title = "On the beach in the sand we built sandcastles",
+                PublishedUtc = DateTime.UtcNow
+            };
+
+            var mountainArticle = new Article
+            {
+                Title = "On the mountain it snowed at the lake",
+                PublishedUtc = DateTime.UtcNow
+            };
+
+            document.Articles.Add(beachLizardsArticle);
+            document.Articles.Add(sandcastlesArticle);
+            document.Articles.Add(mountainArticle);
+
+            // boolean : ((beach AND sand) OR (mountain AND lake)) NOT lizards 
+            var filter = "title:((beach AND sand) OR (mountain AND lake)) NOT lizards";
+            var toFilter = document.Articles.AsEnumerable();
+
+            var parser = new EnumerableEngineBuilder<Article>()
+                .WithNamedTerm("title", b => b
+                    .ManyCondition(
+                        (val, query) => query.Where(x => x.Title.Contains(val, StringComparison.OrdinalIgnoreCase)),
+                        (val, query) => query.Where(x => !x.Title.Contains(val, StringComparison.OrdinalIgnoreCase))
+                    )
+                )
+                .Build();
+
+            var parsed = parser.Parse(filter);
+
+            var filtered = await parsed.ExecuteAsync(toFilter);
+
+            // Parsed query
+            Assert.Equal(2, filtered.Count());
+        }
+
+        [Fact]
+        public async Task ShouldParseNotBooleanQuery()
+        {
+            var document = new ArticleDocument();
+
+            var billsArticle = new Article
+            {
+                Title = "Article by bill about rabbits",
+                PublishedUtc = DateTime.UtcNow
+            };
+
+            var stevesArticle = new Article
+            {
+                Title = "Post by steve about cats",
+                PublishedUtc = DateTime.UtcNow
+            };
+
+            var paulsArticle = new Article
+            {
+                Title = "Blog by paul about chickens",
+                PublishedUtc = DateTime.UtcNow
+            };
+
+            document.Articles.Add(billsArticle);
+            document.Articles.Add(stevesArticle);
+            document.Articles.Add(paulsArticle);
+
+            var filter = "title:NOT steve";
+
+            var toFilter = document.Articles.AsEnumerable();
+
+            var parser = new EnumerableEngineBuilder<Article>()
+                .WithNamedTerm("title", b => b
+                    .ManyCondition(
+                        (val, query) => query.Where(x => x.Title.Contains(val, StringComparison.OrdinalIgnoreCase)),
+                        (val, query) => query.Where(x => !x.Title.Contains(val, StringComparison.OrdinalIgnoreCase))
+                    )
+                )
+                .Build();
+
+            var parsed = parser.Parse(filter);
+
+            var filtered = await parsed.ExecuteAsync(toFilter);
+
+            // Parsed query
+            Assert.Equal(2, filtered.Count());
+        }
+
+        [Fact]
+        public async Task ShouldParseNotQueryWithOrder()
+        {
+            var document = new ArticleDocument();
+
+            var billsArticle = new Article
+            {
+                Title = "Article by bill about rabbits",
+                PublishedUtc = DateTime.UtcNow
+            };
+
+            var stevesArticle = new Article
+            {
+                Title = "Post by steve about cats",
+                PublishedUtc = DateTime.UtcNow
+            };
+
+            var paulsArticle = new Article
+            {
+                Title = "Blog by paul about chickens",
+                PublishedUtc = DateTime.UtcNow
+            };
+
+            document.Articles.Add(billsArticle);
+            document.Articles.Add(stevesArticle);
+            document.Articles.Add(paulsArticle);
+
+            var filter = "title:about NOT steve";
+            var filterQuery = document.Articles.AsEnumerable();
+
+            var parser = new EnumerableEngineBuilder<Article>()
+                .WithNamedTerm("title", b => b
+                    .ManyCondition(
+                        (val, query) => query.Where(x => x.Title.Contains(val, StringComparison.OrdinalIgnoreCase))
+                            .OrderByDescending(x => x.Title),
+                        (val, query) => query
+                            .Where(x => !x.Title.Contains(val, StringComparison.OrdinalIgnoreCase))
+                            .OrderByDescending(x => x.Title)
+                    )
+                )
+                .Build();
+
+            var parsed = parser.Parse(filter);
+
+            var filtered = await parsed.ExecuteAsync(filterQuery);
+
+            // Parsed query
+            Assert.Equal(2, filtered.Count());
+            Assert.Equal("Blog by paul about chickens", filtered.FirstOrDefault().Title);
+        }
+    }
+}

--- a/test/YesSql.Tests/YesSql.Tests.csproj
+++ b/test/YesSql.Tests/YesSql.Tests.csproj
@@ -28,6 +28,7 @@
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\src\YesSql.Core\YesSql.Core.csproj" />
+        <ProjectReference Include="..\..\src\YesSql.Filters.Enumerable\YesSql.Filters.Enumerable.csproj" />
         <ProjectReference Include="..\..\src\YesSql.Provider.MySql\YesSql.Provider.MySql.csproj" />
         <ProjectReference Include="..\..\src\YesSql.Provider.PostgreSql\YesSql.Provider.PostgreSql.csproj" />
         <ProjectReference Include="..\..\src\YesSql.Provider.Sqlite\YesSql.Provider.Sqlite.csproj" />


### PR DESCRIPTION
This introduces a `Enumerable` filters project which allows projecting an enumerable into a Filter Parsing arrangement, much as we can do with an `IQuery` currently.

Filtering on an `IEnumerable` is useful, for the case where we are using a single SQL document, i.e. like a `TemplatesDocument` where the items we want to filter on are contained in a dictionary, or list.

You may or may not want this in the YesSql project :) but I'm using it internally, so figured it was worth pushing up somewhere.

Note: There seems to be a slight bug in Partlot compilation which is causing the tests to fail randomly. I assume it's related to initialization, when initializing in parallel. Only applies to complied parsers.

I'll open an issue there to go with