### PR TITLE
Fix github actions to net 7 and install old version dotnet

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    # as of 12/2022, 3.1 and 5.0 are not installed by default on the images
     - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: | 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,8 +48,17 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: | 
+          3.1.x
+          5.0.x
+
     - name: Build
       run: dotnet build --configuration Release
+
+    - name: Test - Sqlite .NET 7.0
+      run: dotnet test --configuration Release --filter YesSql.Tests.SqliteTests --no-restore --no-build --framework net7.0
 
     - name: Test - Sqlite .NET 6.0
       run: dotnet test --configuration Release --filter YesSql.Tests.SqliteTests --no-restore --no-build --framework net6.0
@@ -60,11 +69,20 @@ jobs:
     - name: Test - Sqlite .NET 3.1
       run: dotnet test --configuration Release --filter YesSql.Tests.SqliteTests --no-restore --no-build --framework netcoreapp3.1
 
+    - name: Test - PostgresQL .NET 7.0
+      run: dotnet test --configuration Release --filter YesSql.Tests.PostgreSqlTests --no-restore --no-build --framework net7.0
+
     - name: Test - PostgresQL .NET 6.0
       run: dotnet test --configuration Release --filter YesSql.Tests.PostgreSqlTests --no-restore --no-build --framework net6.0
 
+    - name: Test - MySQL .NET 7.0
+      run: dotnet test --configuration Release --filter YesSql.Tests.MySqlTests --no-restore --no-build --framework net7.0
+
     - name: Test - MySQL .NET 6.0
       run: dotnet test --configuration Release --filter YesSql.Tests.MySqlTests --no-restore --no-build --framework net6.0
+
+    - name: Test - SQL Server 2019 .NET 7.0
+      run: dotnet test --configuration release --filter YesSql.Tests.SqlServer2019Tests --no-restore --no-build --framework net7.0
 
     - name: Test - SQL Server 2019 .NET 6.0
       run: dotnet test --configuration release --filter YesSql.Tests.SqlServer2019Tests --no-restore --no-build --framework net6.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -48,9 +48,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    
+    - uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: | 
+          3.1.x
+          5.0.x
 
     - name: Build
       run: dotnet build --configuration Release
+
+    - name: Test - Sqlite .NET 7.0
+      run: dotnet test --configuration Release --filter YesSql.Tests.SqliteTests --no-restore --no-build --framework net7.0
 
     - name: Test - Sqlite .NET 6.0
       run: dotnet test --configuration Release --filter YesSql.Tests.SqliteTests --no-restore --no-build --framework net6.0
@@ -61,11 +70,20 @@ jobs:
     - name: Test - Sqlite .NET 3.1
       run: dotnet test --configuration Release --filter YesSql.Tests.SqliteTests --no-restore --no-build --framework netcoreapp3.1
 
+    - name: Test - PostgresQL .NET 7.0
+      run: dotnet test --configuration Release --filter YesSql.Tests.PostgreSqlTests --no-restore --no-build --framework net7.0
+
     - name: Test - PostgresQL .NET 6.0
       run: dotnet test --configuration Release --filter YesSql.Tests.PostgreSqlTests --no-restore --no-build --framework net6.0
 
+    - name: Test - MySQL .NET 7.0
+      run: dotnet test --configuration Release --filter YesSql.Tests.MySqlTests --no-restore --no-build --framework net7.0
+
     - name: Test - MySQL .NET 6.0
       run: dotnet test --configuration Release --filter YesSql.Tests.MySqlTests --no-restore --no-build --framework net6.0
+
+    - name: Test - SQL Server 2019 .NET 7.0
+      run: dotnet test --configuration release --filter YesSql.Tests.SqlServer2019Tests --no-restore --no-build --framework net7.0
 
     - name: Test - SQL Server 2019 .NET 6.0
       run: dotnet test --configuration release --filter YesSql.Tests.SqlServer2019Tests --no-restore --no-build --framework net6.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,6 +49,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     
+    # as of 12/2022, 3.1 and 5.0 are not installed by default on the images
     - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: | 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,23 +60,23 @@ jobs:
     - name: Build
       run: dotnet build --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }}
 
-    - name: Test - Sqlite .NET 6.0
-      run: dotnet test --configuration Release --filter YesSql.Tests.SqliteTests --no-restore --no-build --framework net6.0
+    - name: Test - Sqlite .NET 7.0
+      run: dotnet test --configuration Release --filter YesSql.Tests.SqliteTests --no-restore --no-build --framework net7.0
 
-    - name: Test - PostgresQL .NET 6.0
-      run: dotnet test --configuration Release --filter YesSql.Tests.PostgreSqlTests --no-restore --no-build --framework net6.0
+    - name: Test - PostgresQL .NET 7.0
+      run: dotnet test --configuration Release --filter YesSql.Tests.PostgreSqlTests --no-restore --no-build --framework net7.0
     
-    - name: Test - MySQL .NET 6.0
-      run: dotnet test --configuration Release --filter YesSql.Tests.MySqlTests --no-restore --no-build --framework net6.0
+    - name: Test - MySQL .NET 7.0
+      run: dotnet test --configuration Release --filter YesSql.Tests.MySqlTests --no-restore --no-build --framework net7.0
 
-    - name: Test - SQL Server 2019 .NET 6.0
-      run: dotnet test --configuration release --filter YesSql.Tests.SqlServer2019Tests --no-restore --no-build --framework net6.0
+    - name: Test - SQL Server 2019 .NET 7.0
+      run: dotnet test --configuration release --filter YesSql.Tests.SqlServer2019Tests --no-restore --no-build --framework net7.0
 
     - name: Test - PostgresQL Legacy Identity - No Schema
-      run: dotnet test --configuration release --filter YesSql.Tests.PostgreSqlLegacyIdentityTests --no-restore --no-build --framework net6.0
+      run: dotnet test --configuration release --filter YesSql.Tests.PostgreSqlLegacyIdentityTests --no-restore --no-build --framework net7.0
 
     - name: Test - Sqlite Legacy Identity
-      run: dotnet test --configuration release --filter YesSql.Tests.SqliteLegacyIdentityTests --no-restore --no-build --framework net6.0
+      run: dotnet test --configuration release --filter YesSql.Tests.SqliteLegacyIdentityTests --no-restore --no-build --framework net7.0
 
     - name: Pack
       run: dotnet pack --output artifacts --configuration Release --no-restore --no-build -p:Version=${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
Looks like the github images don't have .net 5 and .net 3 installed anymore.

Installing it, and keeping the old framework tests, plus moving to .net 7 as the default.