### PR TITLE
Reintroduce obsoleted methods

### DIFF
--- a/src/YesSql.Abstractions/IIdGenerator.cs
+++ b/src/YesSql.Abstractions/IIdGenerator.cs
@@ -20,7 +20,6 @@ namespace YesSql
         /// Invoked when the underlying store is created.
         /// </summary>
         /// <param name="store">The store that this <see cref="IIdGenerator"/> instance is assigned to.</param>
-        [Obsolete($"Instead, utilize the {nameof(InitializeAsync)} method with a CancellationToken parameter. This current method is slated for removal in upcoming releases.")]
         Task InitializeAsync(IStore store);
 
         /// <summary>
@@ -31,7 +30,6 @@ namespace YesSql
         /// <summary>
         /// Initializes a document collection.
         /// </summary>
-        [Obsolete($"Instead, utilize the {nameof(InitializeCollectionAsync)} method with a CancellationToken parameter. This current method is slated for removal in upcoming releases.")]
         Task InitializeCollectionAsync(IConfiguration configuration, string collection);
 
         /// <summary>
@@ -39,7 +37,6 @@ namespace YesSql
         /// </summary>
         /// <param name="collection">The name of the collection to generate the identifier for.</param>
         /// <returns>A unique identifier</returns>
-        [Obsolete($"Instead, utilize the {nameof(GetNextIdAsync)} method. This current method is slated for removal in upcoming releases.")]
         long GetNextId(string collection);
 
         /// <summary>
@@ -55,7 +52,6 @@ namespace YesSql
         /// </summary>
         /// <param name="collection">The name of the collection to generate the identifier for.</param>
         /// <returns>A unique identifier</returns>
-        [Obsolete($"Instead, utilize the {nameof(GetNextIdAsync)} method with a CancellationToken parameter. This current method is slated for removal in upcoming releases.")]
         Task<long> GetNextIdAsync(string collection);
     }
 }

--- a/src/YesSql.Abstractions/IQuery.cs
+++ b/src/YesSql.Abstractions/IQuery.cs
@@ -91,7 +91,6 @@ namespace YesSql
         /// <summary>
         /// Executes the query and returns the first result matching the constraints.
         /// </summary>
-        [Obsolete($"Instead, utilize the {nameof(FirstOrDefaultAsync)} method with a CancellationToken parameter. This current method is slated for removal in upcoming releases.")]
         Task<T> FirstOrDefaultAsync();
 
         /// <summary>
@@ -102,7 +101,6 @@ namespace YesSql
         /// <summary>
         /// Executes the query and returns all documents matching the constraints.
         /// </summary>
-        [Obsolete($"Instead, utilize the {nameof(ListAsync)} method with a CancellationToken parameter. This current method is slated for removal in upcoming releases.")]
         Task<IEnumerable<T>> ListAsync();
 
         /// <summary>
@@ -113,7 +111,6 @@ namespace YesSql
         /// <summary>
         /// Executes the query and returns all documents matching the constraints.
         /// </summary>
-        [Obsolete($"Instead, utilize the {nameof(ToAsyncEnumerable)} method with a CancellationToken parameter. This current method is slated for removal in upcoming releases.")]
         IAsyncEnumerable<T> ToAsyncEnumerable();
 
         /// <summary>
@@ -124,7 +121,6 @@ namespace YesSql
         /// <summary>
         /// Executes a that returns the number of documents matching the constraints.
         /// </summary>
-        [Obsolete($"Instead, utilize the {nameof(CountAsync)} method with a CancellationToken parameter. This current method is slated for removal in upcoming releases.")]
         Task<int> CountAsync();
 
         /// <summary>
@@ -214,7 +210,6 @@ namespace YesSql
         /// <summary>
         /// Returns the first result only, if it exists.
         /// </summary>
-        [Obsolete($"Instead, utilize the {nameof(FirstOrDefaultAsync)} method with a CancellationToken parameter. This current method is slated for removal in upcoming releases.")]
         Task<T> FirstOrDefaultAsync();
 
         /// <summary>
@@ -225,7 +220,6 @@ namespace YesSql
         /// <summary>
         /// Executes the query.
         /// </summary>
-        [Obsolete($"Instead, utilize the {nameof(ListAsync)} method with a CancellationToken parameter. This current method is slated for removal in upcoming releases.")]
         Task<IEnumerable<T>> ListAsync();
 
         /// <summary>
@@ -238,7 +232,6 @@ namespace YesSql
         /// Executes the query for asynchronous iteration.
         /// </summary>
         /// <returns></returns>
-        [Obsolete($"Instead, utilize the {nameof(ToAsyncEnumerable)} method with a CancellationToken parameter. This current method is slated for removal in upcoming releases.")]
         IAsyncEnumerable<T> ToAsyncEnumerable();
 
         /// <summary>
@@ -249,7 +242,6 @@ namespace YesSql
         /// <summary>
         /// Returns the number of results only.
         /// </summary>
-        [Obsolete($"Instead, utilize the {nameof(CountAsync)} method with a CancellationToken parameter. This current method is slated for removal in upcoming releases.")]
         Task<int> CountAsync();
     }
 

--- a/src/YesSql.Abstractions/ISchemaBuilder.cs
+++ b/src/YesSql.Abstractions/ISchemaBuilder.cs
@@ -43,67 +43,56 @@ namespace YesSql.Sql
         /// <summary>
         /// Alters an existing table.
         /// </summary>
-        [Obsolete($"Instead, utilize the {nameof(AlterTableAsync)} method. This current method is slated for removal in upcoming releases.")]
         ISchemaBuilder AlterTable(string name, Action<IAlterTableCommand> table);
 
         /// <summary>
         /// Alters an index table.
         /// </summary>
-        [Obsolete($"Instead, utilize the {nameof(AlterIndexTableAsync)} method. This current method is slated for removal in upcoming releases.")]
         ISchemaBuilder AlterIndexTable(Type indexType, Action<IAlterTableCommand> table, string collection);
 
         /// <summary>
         /// Creates a foreign key.
         /// </summary>
-        [Obsolete($"Instead, utilize the {nameof(CreateForeignKeyAsync)} method. This current method is slated for removal in upcoming releases.")]
         ISchemaBuilder CreateForeignKey(string name, string srcTable, string[] srcColumns, string destTable, string[] destColumns);
 
         /// <summary>
         /// Creates a Map Index table.
         /// </summary>
-        [Obsolete($"Instead, utilize the {nameof(CreateMapIndexTableAsync)} method. This current method is slated for removal in upcoming releases.")]
         ISchemaBuilder CreateMapIndexTable(Type indexType, Action<ICreateTableCommand> table, string collection);
 
         /// <summary>
         /// Creates a Reduce Index table. 
         /// </summary>
-        [Obsolete($"Instead, utilize the {nameof(CreateReduceIndexTableAsync)} method. This current method is slated for removal in upcoming releases.")]
         ISchemaBuilder CreateReduceIndexTable(Type indexType, Action<ICreateTableCommand> table, string collection);
 
         /// <summary>
         /// Creates a table.
         /// </summary>
-        [Obsolete($"Instead, utilize the {nameof(CreateTableAsync)} method. This current method is slated for removal in upcoming releases.")]
         ISchemaBuilder CreateTable(string name, Action<ICreateTableCommand> table);
 
         /// <summary>
         /// Removes a foreign key.
         /// </summary>
-        [Obsolete($"Instead, utilize the {nameof(DropForeignKeyAsync)} method. This current method is slated for removal in upcoming releases.")]
         ISchemaBuilder DropForeignKey(string srcTable, string name);
 
         /// <summary>
         /// Removes a Map Index table.
         /// </summary>
-        [Obsolete($"Instead, utilize the {nameof(DropMapIndexTableAsync)} method. This current method is slated for removal in upcoming releases.")]
         ISchemaBuilder DropMapIndexTable(Type indexType, string collection = null);
 
         /// <summary>
         /// Removes a Reduce Index table.
         /// </summary>
-        [Obsolete($"Instead, utilize the {nameof(DropReduceIndexTableAsync)} method. This current method is slated for removal in upcoming releases.")]
         ISchemaBuilder DropReduceIndexTable(Type indexType, string collection = null);
 
         /// <summary>
         /// Removes a table.
         /// </summary>
-        [Obsolete($"Instead, utilize the {nameof(DropTableAsync)} method. This current method is slated for removal in upcoming releases.")]
         ISchemaBuilder DropTable(string name);
 
         /// <summary>
         /// Creates a database schema.
         /// </summary>
-        [Obsolete($"Instead, utilize the {nameof(CreateSchemaAsync)} method. This current method is slated for removal in upcoming releases.")]
         ISchemaBuilder CreateSchema(string schema);
 
 

--- a/src/YesSql.Abstractions/ISession.cs
+++ b/src/YesSql.Abstractions/ISession.cs
@@ -20,7 +20,6 @@ namespace YesSql
         /// <param name="obj">The entity to save.</param>
         /// <param name="checkConcurrency">If true, a <see cref="ConcurrencyException"/> is thrown if the entity has been updated concurrently by another session.</param>
         /// <param name="collection">The name of the collection to store the object in.</param>
-        [Obsolete($"Instead, utilize the {nameof(SaveAsync)} method. This current method is slated for removal in upcoming releases.")]
         void Save(object obj, bool checkConcurrency = false, string collection = null);
 
 
@@ -41,7 +40,6 @@ namespace YesSql
         /// <param name="obj">The entity to save.</param>
         /// <param name="checkConcurrency">If true, a <see cref="ConcurrencyException"/> is thrown if the entity has been updated concurrently by another session.</param>
         /// <param name="collection">The name of the collection to store the object in.</param>
-        [Obsolete($"Instead, utilize the {nameof(SaveAsync)} method with a CancellationToken parameter. This current method is slated for removal in upcoming releases.")]
         Task SaveAsync(object obj, bool checkConcurrency, string collection);
 
         /// <summary>
@@ -50,7 +48,6 @@ namespace YesSql
         /// </summary>
         /// <param name="obj">The entity to save.</param>
         /// <param name="checkConcurrency">If true, a <see cref="ConcurrencyException"/> is thrown if the entity has been updated concurrently by another session.</param>
-        [Obsolete($"Instead, utilize the {nameof(SaveAsync)} method with a CancellationToken parameter. This current method is slated for removal in upcoming releases.")]
         Task SaveAsync(object obj, bool checkConcurrency);
 
         /// <summary>
@@ -58,7 +55,6 @@ namespace YesSql
         /// the corresponding indexes.
         /// </summary>
         /// <param name="obj">The entity to save.</param>
-        [Obsolete($"Instead, utilize the {nameof(SaveAsync)} method with a CancellationToken parameter. This current method is slated for removal in upcoming releases.")]
         Task SaveAsync(object obj);
 
         /// <summary>
@@ -115,14 +111,12 @@ namespace YesSql
         /// Loads objects by id.
         /// </summary>
         /// <returns>A collection of objects in the same order they were defined.</returns>
-        [Obsolete($"Instead, utilize the {nameof(GetAsync)} method with a CancellationToken parameter. This current method is slated for removal in upcoming releases.")]
         Task<IEnumerable<T>> GetAsync<T>(long[] ids, string collection) where T : class;
 
         /// <summary>
         /// Loads objects by id.
         /// </summary>
         /// <returns>A collection of objects in the same order they were defined.</returns>
-        [Obsolete($"Instead, utilize the {nameof(GetAsync)} method with a CancellationToken parameter. This current method is slated for removal in upcoming releases.")]
         Task<IEnumerable<T>> GetAsync<T>(long[] ids) where T : class;
 
         /// <summary>
@@ -168,7 +162,6 @@ namespace YesSql
         /// This doesn't commit or dispose of the transaction. A call to <see cref="SaveChangesAsync(CancellationToken)"/>
         /// is still necessary for the changes to be visible from other transactions.
         /// </remarks>
-        [Obsolete($"Instead, utilize the {nameof(FlushAsync)} method with a CancellationToken parameter. This current method is slated for removal in upcoming releases.")]
         Task FlushAsync();
 
         /// <summary>
@@ -187,7 +180,6 @@ namespace YesSql
         /// Sessions are not automatically committed when disposed, and <see cref="SaveChangesAsync(CancellationToken)"/>
         /// must be called before disposing the <see cref="ISession"/>
         /// </remarks>
-        [Obsolete($"Instead, utilize the {nameof(SaveChangesAsync)} method with a CancellationToken parameter. This current method is slated for removal in upcoming releases.")]
         Task SaveChangesAsync();
 
         /// <summary>
@@ -198,7 +190,6 @@ namespace YesSql
         /// <summary>
         /// Creates or returns a <see cref="DbConnection"/>.
         /// </summary>
-        [Obsolete($"Instead, utilize the {nameof(CreateConnectionAsync)} method with a CancellationToken parameter. This current method is slated for removal in upcoming releases.")]
         Task<DbConnection> CreateConnectionAsync();
 
         /// <summary>
@@ -209,7 +200,6 @@ namespace YesSql
         /// <summary>
         /// Creates or returns an existing <see cref="DbTransaction"/> with the default isolation level.
         /// </summary>
-        [Obsolete($"Instead, utilize the {nameof(BeginTransactionAsync)} method with a CancellationToken parameter. This current method is slated for removal in upcoming releases.")]
         Task<DbTransaction> BeginTransactionAsync();
 
         /// <summary>
@@ -220,7 +210,6 @@ namespace YesSql
         /// <summary>
         /// Creates or returns an existing <see cref="DbTransaction"/> with the specified isolation level.
         /// </summary>
-        [Obsolete($"Instead, utilize the {nameof(BeginTransactionAsync)} method with a CancellationToken parameter. This current method is slated for removal in upcoming releases.")]
         Task<DbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel);
 
         /// <summary>

--- a/src/YesSql.Abstractions/IStore.cs
+++ b/src/YesSql.Abstractions/IStore.cs
@@ -34,7 +34,6 @@ namespace YesSql
         /// <summary>
         /// Initializes the database by creating the required tables and the default collection if necessary.
         /// </summary>
-        [Obsolete($"Instead, utilize the {nameof(InitializeAsync)} method with a CancellationToken parameter. This current method is slated for removal in upcoming releases.")]
         Task InitializeAsync();
 
         /// <summary>
@@ -45,7 +44,6 @@ namespace YesSql
         /// <summary>
         /// Initializes a collection in the database by creating the required tables if necessary.
         /// </summary>
-        [Obsolete($"Instead, utilize the {nameof(InitializeCollectionAsync)} method with a CancellationToken parameter. This current method is slated for removal in upcoming releases.")]
         Task InitializeCollectionAsync(string collection);
 
         /// <summary>


### PR DESCRIPTION
This prevents source-breaking changes. Since the overload with the default argument is not picked up automatically it. This is too disruptive. If these methods were actually completely removed there wouldn't be any build breaks. (another PR for 6.0)
