### PR TITLE
Replace vulnerable Microsoft.Data.Sqlite with Core + explicit SQLitePCLRaw bundle

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -127,15 +127,4 @@
         
     </PropertyGroup>
 
-    <!-- Transitive audit suppress: Microsoft.Data.Sqlite → SQLitePCLRaw.lib.e_sqlite3 2.1.11
-    is flagged by NuGetAudit (GHSA-2m69-gcr7-jv3q, CVE-2025-6965 — SQLite < 3.50.2
-    memory corruption in aggregate-term handling). No patched version of
-    SQLitePCLRaw.lib.e_sqlite3 is available on NuGet: 3.50.3 was published then unlisted,
-    and 2.1.11 remains the latest stable release. This suppress will be removed once
-    Microsoft ships a Microsoft.Data.Sqlite release that pins a non-vulnerable
-    SQLitePCLRaw.lib.e_sqlite3. Track: https://github.com/dotnet/efcore/issues/38257 -->
-    <ItemGroup>
-        <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
-    </ItemGroup>
-
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,7 +5,8 @@
   <ItemGroup>
     <PackageVersion Include="Parlot" Version="$(ParlotPackageVersion)" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="$(MicrosoftDataSqlClientPackageVersion)" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="$(MicrosoftDataSqlitePackageVersion)" />
+    <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="$(MicrosoftDataSqlitePackageVersion)" />
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="$(SQLitePCLRawBundleESqlite3PackageVersion)" />
     <PackageVersion Include="Npgsql" Version="$(NpgsqlPackageVersion)" />
     <PackageVersion Include="MySqlConnector" Version="$(MySqlConnectorPackageVersion)" />
     <PackageVersion Include="Dapper.StrongName" Version="$(DapperStrongNamePackageVersion)" />
@@ -16,16 +17,5 @@
 
   <ItemGroup>
     <GlobalPackageReference Include="Meziantou.Analyzer" Version="2.0.298" />
-  </ItemGroup>
-
-  <!-- Transitive audit suppress: Microsoft.Data.Sqlite → SQLitePCLRaw.lib.e_sqlite3 2.1.11
-  is flagged by NuGetAudit (GHSA-2m69-gcr7-jv3q, CVE-2025-6965 — SQLite < 3.50.2
-  memory corruption in aggregate-term handling). No patched version of
-  SQLitePCLRaw.lib.e_sqlite3 is available on NuGet: 3.50.3 was published then unlisted,
-  and 2.1.11 remains the latest stable release. This suppress will be removed once
-  Microsoft ships a Microsoft.Data.Sqlite release that pins a non-vulnerable
-  SQLitePCLRaw.lib.e_sqlite3. Track: https://github.com/dotnet/efcore/issues/38257 -->
-  <ItemGroup>
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
   </ItemGroup>
 </Project>

--- a/src/Versions.props
+++ b/src/Versions.props
@@ -6,6 +6,7 @@
       <MicrosoftDataSqlClientPackageVersion>7.0.1</MicrosoftDataSqlClientPackageVersion>
       <MySqlConnectorPackageVersion>2.5.0</MySqlConnectorPackageVersion>
       <MicrosoftDataSqlitePackageVersion>10.0.9</MicrosoftDataSqlitePackageVersion>
+      <SQLitePCLRawBundleESqlite3PackageVersion>3.0.3</SQLitePCLRawBundleESqlite3PackageVersion>
       <NpgsqlPackageVersion>10.0.3</NpgsqlPackageVersion>
       <ParlotPackageVersion>1.5.7</ParlotPackageVersion>
   </PropertyGroup>

--- a/src/YesSql.Provider.Sqlite/YesSql.Provider.Sqlite.csproj
+++ b/src/YesSql.Provider.Sqlite/YesSql.Provider.Sqlite.csproj
@@ -5,7 +5,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Data.Sqlite" />
+        <!-- Using Microsoft.Data.Sqlite.Core + an explicit SQLitePCLRaw.bundle_e_sqlite3
+             to control the native SQLite version and avoid the vulnerable transitive
+             dependency. Switch back to the Microsoft.Data.Sqlite meta-package once a
+             stable (generally available) release pins a non-vulnerable SQLitePCLRaw. -->
+        <PackageReference Include="Microsoft.Data.Sqlite.Core" />
+        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Why

The `Microsoft.Data.Sqlite` meta-package pulls in `SQLitePCLRaw.lib.e_sqlite3` 2.1.11 transitively, which NuGetAudit flags for GHSA-2m69-gcr7-jv3q / CVE-2025-6965 (SQLite < 3.50.2 memory corruption in aggregate-term handling). We were suppressing that audit warning while waiting for a patched release.

## What

Instead of suppressing the warning, this swaps to a setup where we control the native SQLite version directly:

- Replace `Microsoft.Data.Sqlite` with `Microsoft.Data.Sqlite.Core` plus an explicit `SQLitePCLRaw.bundle_e_sqlite3` 3.0.3 reference, which bundles a non-vulnerable native SQLite.
- Remove the two `NuGetAuditSuppress` rules (in `Directory.Build.props` and `src/Directory.Packages.props`) since the vulnerable transitive dependency is gone.
- Wire the new package version through central package management (`Versions.props` / `Directory.Packages.props`).

## Notes

A comment on the package reference explains the rationale and notes we can revert to the `Microsoft.Data.Sqlite` meta-package once a stable release pins a non-vulnerable SQLitePCLRaw. The provider builds with 0 warnings, confirming the suppression is no longer needed.