### PR TITLE
Fix DateTimeOffset round-trip to be timezone independent

### DIFF
--- a/src/YesSql.Core/Data/DapperDataHandlers.cs
+++ b/src/YesSql.Core/Data/DapperDataHandlers.cs
@@ -1,6 +1,7 @@
 using Dapper;
 using System;
 using System.Data;
+using System.Globalization;
 
 namespace YesSql.Data
 {
@@ -20,10 +21,16 @@ namespace YesSql.Data
                     return DateTimeOffset.MinValue;
 
                 case string s:
-                    return DateTimeOffset.Parse(s);
+                    // Values stored in TEXT columns (e.g. Sqlite) don't keep the offset and are
+                    // persisted as UTC. Treat offset-less strings as UTC so the instant round-trips
+                    // regardless of the local timezone. Strings that carry an explicit offset
+                    // (e.g. MySql 'O' format) keep their offset.
+                    return DateTimeOffset.Parse(s, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
 
                 case DateTime dt:
-                    return new DateTimeOffset(dt);
+                    // DateTime values are stored as UTC. A value read back as Unspecified must be
+                    // interpreted as UTC, otherwise the local timezone would shift the instant.
+                    return new DateTimeOffset(dt.Kind == DateTimeKind.Unspecified ? DateTime.SpecifyKind(dt, DateTimeKind.Utc) : dt);
 
                 case DateTimeOffset d:
                     return d;


### PR DESCRIPTION
## Why

Three SQLite tests (`AllDataTypesShouldBeStored`, `AllDataTypesShouldBeQueryableWithProperties`, `AllDataTypesShouldBeQueryableWithConstants`) failed on any machine whose local timezone is not UTC. They passed on CI only because the runner happens to be UTC. The root cause was a real round-trip bug, not a flaky test.

## Root cause

`DateTimeOffset` values are written using their `.UtcDateTime`, and providers without a native offset type (e.g. SQLite) persist them as offset-less TEXT (`"2021-01-19 22:58:00"`). On read, `DateTimeOffsetHandler.Parse` called `DateTimeOffset.Parse(s)`, which assumes the **local** timezone for offset-less strings. On a UTC-7 machine this turned the stored UTC instant into `...-08:00`, shifting it by the local offset and corrupting the value. On a UTC machine the offset is zero, so it accidentally matched.

## Fix

In `DateTimeOffsetHandler.Parse`:
- Parse offset-less strings with `DateTimeStyles.AssumeUniversal` so stored UTC values are interpreted as UTC. Strings that carry an explicit offset (e.g. the MySQL `"O"` format) keep their offset.
- Interpret an `Unspecified`-kind `DateTime` as UTC for the same reason.

The stored value is always UTC, so this makes the instant round-trip correctly regardless of the host timezone.

## Verification

`AllDataTypes` tests pass under the local `America/Los_Angeles` timezone across all providers:

- SQLite: full `SqliteTests` suite green under both PST and UTC
- PostgreSQL 16: 3/3 green (native `timestamptz`, unaffected but confirms no regression)
- SQL Server 2019: 3/3 green (native `DATETIMEOFFSET`, unaffected but confirms no regression)

## Note

Under positive-offset zones (e.g. `Asia/Kolkata`) there are 4 additional pre-existing failures in reduced-index `DayOfYear` grouping tests. Those involve `DateTime` (not `DateTimeOffset`), are unrelated to this change, and do not manifest on a UTC-7 machine. They are left out of scope here.