### PR TITLE
Complete public API XML documentation

### DIFF
--- a/src/YesSql.Abstractions/Commands/IAddColumnCommand.cs
+++ b/src/YesSql.Abstractions/Commands/IAddColumnCommand.cs
@@ -1,5 +1,8 @@
 ﻿namespace YesSql.Sql.Schema
 {
+    /// <summary>
+    /// Represents a command that adds a new column to an existing table.
+    /// </summary>
     public interface IAddColumnCommand : ICreateColumnCommand
     {
     }

--- a/src/YesSql.Abstractions/Commands/IAddIndexCommand.cs
+++ b/src/YesSql.Abstractions/Commands/IAddIndexCommand.cs
@@ -1,8 +1,18 @@
 ﻿namespace YesSql.Sql.Schema
 {
+    /// <summary>
+    /// Represents a command that creates an index on one or more columns of a table.
+    /// </summary>
     public interface IAddIndexCommand : ITableCommand
     {
+        /// <summary>
+        /// Gets or sets the name of the index to create.
+        /// </summary>
         string IndexName { get; set; }
+
+        /// <summary>
+        /// Gets the names of the columns that the index is defined on.
+        /// </summary>
         string[] ColumnNames { get; }
     }
 }

--- a/src/YesSql.Abstractions/Commands/IAlterColumnCommand.cs
+++ b/src/YesSql.Abstractions/Commands/IAlterColumnCommand.cs
@@ -2,9 +2,26 @@ using System;
 
 namespace YesSql.Sql.Schema
 {
+    /// <summary>
+    /// Represents a command that changes the definition of an existing column.
+    /// </summary>
     public interface IAlterColumnCommand : IColumnCommand
     {
+        /// <summary>
+        /// Sets the data type of the column.
+        /// </summary>
+        /// <param name="dbType">The .NET type mapped to the database column type.</param>
+        /// <param name="length">The maximum length of the column, or <c>null</c> for the default length.</param>
+        /// <returns>The current <see cref="IAlterColumnCommand"/> instance so that calls can be chained.</returns>
         IAlterColumnCommand WithType(Type dbType, int? length);
+
+        /// <summary>
+        /// Sets the data type of the column using a fixed precision and scale.
+        /// </summary>
+        /// <param name="dbType">The .NET type mapped to the database column type.</param>
+        /// <param name="precision">The total number of digits stored for the column.</param>
+        /// <param name="scale">The number of digits stored to the right of the decimal point.</param>
+        /// <returns>The current <see cref="IAlterColumnCommand"/> instance so that calls can be chained.</returns>
         IAlterColumnCommand WithType(Type dbType, byte precision, byte scale);
     }
 }

--- a/src/YesSql.Abstractions/Commands/IAlterTableCommand.cs
+++ b/src/YesSql.Abstractions/Commands/IAlterTableCommand.cs
@@ -2,14 +2,59 @@ using System;
 
 namespace YesSql.Sql.Schema
 {
+    /// <summary>
+    /// Represents a command that alters an existing table by adding, changing,
+    /// renaming or removing columns and indexes.
+    /// </summary>
     public interface IAlterTableCommand : ISchemaCommand
     {
+        /// <summary>
+        /// Adds a new column to the table.
+        /// </summary>
+        /// <param name="columnName">The name of the column to add.</param>
+        /// <param name="dbType">The .NET type mapped to the database column type.</param>
+        /// <param name="column">An optional delegate used to further configure the column.</param>
         void AddColumn(string columnName, Type dbType, Action<IAddColumnCommand> column = null);
+
+        /// <summary>
+        /// Adds a new column to the table.
+        /// </summary>
+        /// <typeparam name="T">The .NET type mapped to the database column type.</typeparam>
+        /// <param name="columnName">The name of the column to add.</param>
+        /// <param name="column">An optional delegate used to further configure the column.</param>
         void AddColumn<T>(string columnName, Action<IAddColumnCommand> column = null);
+
+        /// <summary>
+        /// Alters the definition of an existing column.
+        /// </summary>
+        /// <param name="columnName">The name of the column to alter.</param>
+        /// <param name="column">An optional delegate used to configure the new column definition.</param>
         void AlterColumn(string columnName, Action<IAlterColumnCommand> column = null);
+
+        /// <summary>
+        /// Renames an existing column.
+        /// </summary>
+        /// <param name="columnName">The current name of the column.</param>
+        /// <param name="newName">The new name of the column.</param>
         void RenameColumn(string columnName, string newName);
+
+        /// <summary>
+        /// Removes an existing column from the table.
+        /// </summary>
+        /// <param name="columnName">The name of the column to drop.</param>
         void DropColumn(string columnName);
+
+        /// <summary>
+        /// Creates an index on the table.
+        /// </summary>
+        /// <param name="indexName">The name of the index to create.</param>
+        /// <param name="columnNames">The names of the columns the index is defined on.</param>
         void CreateIndex(string indexName, params string[] columnNames);
+
+        /// <summary>
+        /// Removes an existing index from the table.
+        /// </summary>
+        /// <param name="indexName">The name of the index to drop.</param>
         void DropIndex(string indexName);
     }
 }

--- a/src/YesSql.Abstractions/Commands/IColumnCommand.cs
+++ b/src/YesSql.Abstractions/Commands/IColumnCommand.cs
@@ -2,24 +2,59 @@ using System;
 
 namespace YesSql.Sql.Schema
 {
+    /// <summary>
+    /// Represents a command that operates on a single column of a table.
+    /// </summary>
     public interface IColumnCommand : ITableCommand
     {
+        /// <summary>
+        /// Gets the name of the column.
+        /// </summary>
         string ColumnName { get; }
 
+        /// <summary>
+        /// Gets the number of digits stored to the right of the decimal point, or <c>null</c> when not specified.
+        /// </summary>
         byte? Scale { get; }
 
+        /// <summary>
+        /// Gets the total number of digits stored for the column, or <c>null</c> when not specified.
+        /// </summary>
         byte? Precision { get; }
 
+        /// <summary>
+        /// Gets the .NET type mapped to the database column type.
+        /// </summary>
         Type DbType { get; }
 
+        /// <summary>
+        /// Gets the default value assigned to the column.
+        /// </summary>
         object Default { get; }
 
+        /// <summary>
+        /// Gets the maximum length of the column, or <c>null</c> when not specified.
+        /// </summary>
         int? Length { get; }
 
+        /// <summary>
+        /// Sets the default value of the column.
+        /// </summary>
+        /// <param name="default">The default value to assign to the column.</param>
+        /// <returns>The current <see cref="IColumnCommand"/> instance so that calls can be chained.</returns>
         IColumnCommand WithDefault(object @default);
 
+        /// <summary>
+        /// Sets the maximum length of the column.
+        /// </summary>
+        /// <param name="length">The maximum length, or <c>null</c> for the default length.</param>
+        /// <returns>The current <see cref="IColumnCommand"/> instance so that calls can be chained.</returns>
         IColumnCommand WithLength(int? length);
 
+        /// <summary>
+        /// Configures the column to store an unlimited amount of data.
+        /// </summary>
+        /// <returns>The current <see cref="IColumnCommand"/> instance so that calls can be chained.</returns>
         IColumnCommand Unlimited();
     }
 }

--- a/src/YesSql.Abstractions/Commands/ICreateColumnCommand.cs
+++ b/src/YesSql.Abstractions/Commands/ICreateColumnCommand.cs
@@ -1,29 +1,78 @@
 namespace YesSql.Sql.Schema
 {
+    /// <summary>
+    /// Represents a command that creates a new column on a table.
+    /// </summary>
     public interface ICreateColumnCommand : IColumnCommand
     {
+        /// <summary>
+        /// Gets a value indicating whether the column has a unique constraint.
+        /// </summary>
         bool IsUnique { get; }
 
+        /// <summary>
+        /// Gets a value indicating whether the column does not accept <c>null</c> values.
+        /// </summary>
         bool IsNotNull { get; }
 
+        /// <summary>
+        /// Gets a value indicating whether the column is part of the primary key.
+        /// </summary>
         bool IsPrimaryKey { get; }
 
+        /// <summary>
+        /// Gets a value indicating whether the column is an auto-incremented identity column.
+        /// </summary>
         bool IsIdentity { get; }
 
+        /// <summary>
+        /// Marks the column as the primary key of the table.
+        /// </summary>
+        /// <returns>The current <see cref="ICreateColumnCommand"/> instance so that calls can be chained.</returns>
         ICreateColumnCommand PrimaryKey();
 
+        /// <summary>
+        /// Marks the column as an auto-incremented identity column.
+        /// </summary>
+        /// <returns>The current <see cref="ICreateColumnCommand"/> instance so that calls can be chained.</returns>
         ICreateColumnCommand Identity();
 
+        /// <summary>
+        /// Sets the total number of digits stored for the column.
+        /// </summary>
+        /// <param name="precision">The precision, or <c>null</c> for the default precision.</param>
+        /// <returns>The current <see cref="ICreateColumnCommand"/> instance so that calls can be chained.</returns>
         ICreateColumnCommand WithPrecision(byte? precision);
 
+        /// <summary>
+        /// Sets the number of digits stored to the right of the decimal point.
+        /// </summary>
+        /// <param name="scale">The scale, or <c>null</c> for the default scale.</param>
+        /// <returns>The current <see cref="ICreateColumnCommand"/> instance so that calls can be chained.</returns>
         ICreateColumnCommand WithScale(byte? scale);
 
+        /// <summary>
+        /// Marks the column as not accepting <c>null</c> values.
+        /// </summary>
+        /// <returns>The current <see cref="ICreateColumnCommand"/> instance so that calls can be chained.</returns>
         ICreateColumnCommand NotNull();
 
+        /// <summary>
+        /// Marks the column as accepting <c>null</c> values.
+        /// </summary>
+        /// <returns>The current <see cref="ICreateColumnCommand"/> instance so that calls can be chained.</returns>
         ICreateColumnCommand Nullable();
 
+        /// <summary>
+        /// Adds a unique constraint to the column.
+        /// </summary>
+        /// <returns>The current <see cref="ICreateColumnCommand"/> instance so that calls can be chained.</returns>
         ICreateColumnCommand Unique();
 
+        /// <summary>
+        /// Removes the unique constraint from the column.
+        /// </summary>
+        /// <returns>The current <see cref="ICreateColumnCommand"/> instance so that calls can be chained.</returns>
         ICreateColumnCommand NotUnique();
     }
 }

--- a/src/YesSql.Abstractions/Commands/ICreateForeignKeyCommand.cs
+++ b/src/YesSql.Abstractions/Commands/ICreateForeignKeyCommand.cs
@@ -1,13 +1,28 @@
 ﻿namespace YesSql.Sql.Schema
 {
+    /// <summary>
+    /// Represents a command that creates a foreign key constraint between two tables.
+    /// </summary>
     public interface ICreateForeignKeyCommand : ISchemaCommand
     {
+        /// <summary>
+        /// Gets the names of the referenced columns in the destination table.
+        /// </summary>
         string[] DestColumns { get; }
 
+        /// <summary>
+        /// Gets the name of the destination (referenced) table.
+        /// </summary>
         string DestTable { get; }
 
+        /// <summary>
+        /// Gets the names of the columns in the source table that make up the foreign key.
+        /// </summary>
         string[] SrcColumns { get; }
 
+        /// <summary>
+        /// Gets the name of the source (referencing) table.
+        /// </summary>
         string SrcTable { get; }
     }
 }

--- a/src/YesSql.Abstractions/Commands/ICreateSchemaCommand.cs
+++ b/src/YesSql.Abstractions/Commands/ICreateSchemaCommand.cs
@@ -1,5 +1,8 @@
 namespace YesSql.Sql.Schema
 {
+    /// <summary>
+    /// Represents a command that creates a new database schema.
+    /// </summary>
     public interface ICreateSchemaCommand : ISchemaCommand
     {
     }

--- a/src/YesSql.Abstractions/Commands/ICreateTableCommand.cs
+++ b/src/YesSql.Abstractions/Commands/ICreateTableCommand.cs
@@ -2,10 +2,36 @@ using System;
 
 namespace YesSql.Sql.Schema
 {
+    /// <summary>
+    /// Represents a command that creates a new table.
+    /// </summary>
     public interface ICreateTableCommand : ISchemaCommand
     {
+        /// <summary>
+        /// Adds a column to the table being created.
+        /// </summary>
+        /// <param name="columnName">The name of the column to add.</param>
+        /// <param name="dbType">The .NET type mapped to the database column type.</param>
+        /// <param name="column">An optional delegate used to further configure the column.</param>
+        /// <returns>The current <see cref="ICreateTableCommand"/> instance so that calls can be chained.</returns>
         ICreateTableCommand Column(string columnName, Type dbType, Action<ICreateColumnCommand> column = null);
+
+        /// <summary>
+        /// Adds a column to the table being created.
+        /// </summary>
+        /// <typeparam name="T">The .NET type mapped to the database column type.</typeparam>
+        /// <param name="columnName">The name of the column to add.</param>
+        /// <param name="column">An optional delegate used to further configure the column.</param>
+        /// <returns>The current <see cref="ICreateTableCommand"/> instance so that calls can be chained.</returns>
         ICreateTableCommand Column<T>(string columnName, Action<ICreateColumnCommand> column = null);
+
+        /// <summary>
+        /// Adds an identity column to the table being created, using the type matching the specified size.
+        /// </summary>
+        /// <param name="identityColumnSize">The size of the identity column, which determines whether an <see cref="int"/> or a <see cref="long"/> column is created.</param>
+        /// <param name="columnName">The name of the column to add.</param>
+        /// <param name="column">An optional delegate used to further configure the column.</param>
+        /// <returns>The current <see cref="ICreateTableCommand"/> instance so that calls can be chained.</returns>
         public ICreateTableCommand Column(IdentityColumnSize identityColumnSize, string columnName, Action<ICreateColumnCommand> column = null) => identityColumnSize == IdentityColumnSize.Int32 ? Column<int>(columnName, column) : Column<long>(columnName, column);
     }
 }

--- a/src/YesSql.Abstractions/Commands/IDropColumnCommand.cs
+++ b/src/YesSql.Abstractions/Commands/IDropColumnCommand.cs
@@ -1,5 +1,8 @@
 ﻿namespace YesSql.Sql.Schema
 {
+    /// <summary>
+    /// Represents a command that removes an existing column from a table.
+    /// </summary>
     public interface IDropColumnCommand : IColumnCommand
     {
     }

--- a/src/YesSql.Abstractions/Commands/IDropForeignKeyCommand.cs
+++ b/src/YesSql.Abstractions/Commands/IDropForeignKeyCommand.cs
@@ -1,7 +1,13 @@
 ﻿namespace YesSql.Sql.Schema
 {
+    /// <summary>
+    /// Represents a command that removes an existing foreign key constraint.
+    /// </summary>
     public interface IDropForeignKeyCommand : ISchemaCommand
     {
+        /// <summary>
+        /// Gets the name of the source table that the foreign key is defined on.
+        /// </summary>
         string SrcTable { get; }
     }
 }

--- a/src/YesSql.Abstractions/Commands/IDropIndexCommand.cs
+++ b/src/YesSql.Abstractions/Commands/IDropIndexCommand.cs
@@ -1,7 +1,13 @@
 ﻿namespace YesSql.Sql.Schema
 {
+    /// <summary>
+    /// Represents a command that removes an existing index from a table.
+    /// </summary>
     public interface IDropIndexCommand : ITableCommand
     {
+        /// <summary>
+        /// Gets or sets the name of the index to drop.
+        /// </summary>
         string IndexName { get; set; }
     }
 }

--- a/src/YesSql.Abstractions/Commands/IDropTableCommand.cs
+++ b/src/YesSql.Abstractions/Commands/IDropTableCommand.cs
@@ -1,5 +1,8 @@
 ﻿namespace YesSql.Sql.Schema
 {
+    /// <summary>
+    /// Represents a command that removes an existing table.
+    /// </summary>
     public interface IDropTableCommand : ISchemaCommand
     {
     }

--- a/src/YesSql.Abstractions/Commands/IRenameColumnCommand.cs
+++ b/src/YesSql.Abstractions/Commands/IRenameColumnCommand.cs
@@ -1,7 +1,13 @@
 namespace YesSql.Sql.Schema
 {
+    /// <summary>
+    /// Represents a command that renames an existing column.
+    /// </summary>
     public interface IRenameColumnCommand : IColumnCommand
     {
+        /// <summary>
+        /// Gets the new name of the column.
+        /// </summary>
         string NewColumnName { get; }
     }
 }

--- a/src/YesSql.Abstractions/Commands/ISchemaCommand.cs
+++ b/src/YesSql.Abstractions/Commands/ISchemaCommand.cs
@@ -2,20 +2,60 @@ using System.Collections.Generic;
 
 namespace YesSql.Sql.Schema
 {
+    /// <summary>
+    /// Represents a schema modification command, such as creating, altering or dropping a table.
+    /// </summary>
     public interface ISchemaCommand
     {
+        /// <summary>
+        /// Gets the name of the schema object the command operates on.
+        /// </summary>
         string Name { get; }
+
+        /// <summary>
+        /// Gets the list of table commands that make up this schema command.
+        /// </summary>
         List<ITableCommand> TableCommands { get; }
     }
 
+    /// <summary>
+    /// Defines the types of schema commands that can be issued.
+    /// </summary>
     public enum SchemaCommandType
     {
+        /// <summary>
+        /// A command that creates a table.
+        /// </summary>
         CreateTable,
+
+        /// <summary>
+        /// A command that drops a table.
+        /// </summary>
         DropTable,
+
+        /// <summary>
+        /// A command that alters an existing table.
+        /// </summary>
         AlterTable,
+
+        /// <summary>
+        /// A command that executes a raw SQL statement.
+        /// </summary>
         SqlStatement,
+
+        /// <summary>
+        /// A command that creates a foreign key constraint.
+        /// </summary>
         CreateForeignKey,
+
+        /// <summary>
+        /// A command that drops a foreign key constraint.
+        /// </summary>
         DropForeignKey,
+
+        /// <summary>
+        /// A command that creates a database schema.
+        /// </summary>
         CreateSchema,
     }
 }

--- a/src/YesSql.Abstractions/Commands/ISqlStatementCommand.cs
+++ b/src/YesSql.Abstractions/Commands/ISqlStatementCommand.cs
@@ -2,9 +2,19 @@
 
 namespace YesSql.Sql.Schema
 {
+    /// <summary>
+    /// Represents a command that executes a raw SQL statement against the database.
+    /// </summary>
     public interface ISqlStatementCommand : ISchemaCommand
     {
+        /// <summary>
+        /// Gets the raw SQL statement to execute.
+        /// </summary>
         string Sql { get; }
+
+        /// <summary>
+        /// Gets the list of database providers the statement applies to. An empty list means it applies to all providers.
+        /// </summary>
         List<string> Providers { get; }
     }
 }

--- a/src/YesSql.Abstractions/Commands/ITableCommand.cs
+++ b/src/YesSql.Abstractions/Commands/ITableCommand.cs
@@ -1,5 +1,8 @@
 ﻿namespace YesSql.Sql.Schema
 {
+    /// <summary>
+    /// Represents a schema command that operates on a table.
+    /// </summary>
     public interface ITableCommand : ISchemaCommand
     {
     }

--- a/src/YesSql.Abstractions/ConcurrencyException.cs
+++ b/src/YesSql.Abstractions/ConcurrencyException.cs
@@ -3,10 +3,21 @@ using System.Reflection.Metadata;
 
 namespace YesSql
 {
+    /// <summary>
+    /// The exception that is thrown when a document could not be updated because it has been
+    /// changed concurrently by another process.
+    /// </summary>
     public class ConcurrencyException : Exception
     {
+        /// <summary>
+        /// Gets the document that could not be updated.
+        /// </summary>
         public Document Document { get; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConcurrencyException"/> class.
+        /// </summary>
+        /// <param name="document">The document that could not be updated.</param>
         public ConcurrencyException(Document document) : base($"The document with Id '{document.Id}' and type '{document.Type}' could not be updated as it has been changed by another process.")
         {
             Document = document;

--- a/src/YesSql.Abstractions/ICommandInterpreter.cs
+++ b/src/YesSql.Abstractions/ICommandInterpreter.cs
@@ -9,17 +9,88 @@ namespace YesSql
     /// </summary>
     public interface ICommandInterpreter
     {
+        /// <summary>
+        /// Generates the SQL statements for a set of schema commands.
+        /// </summary>
+        /// <param name="commands">The schema commands to translate.</param>
+        /// <returns>The SQL statements that implement the commands.</returns>
         IEnumerable<string> CreateSql(IEnumerable<ISchemaCommand> commands);
+
+        /// <summary>
+        /// Generates the SQL statements for a create table command.
+        /// </summary>
+        /// <param name="command">The command to translate.</param>
+        /// <returns>The SQL statements that create the table.</returns>
         IEnumerable<string> Run(ICreateTableCommand command);
+
+        /// <summary>
+        /// Generates the SQL statements for a drop table command.
+        /// </summary>
+        /// <param name="command">The command to translate.</param>
+        /// <returns>The SQL statements that drop the table.</returns>
         IEnumerable<string> Run(IDropTableCommand command);
+
+        /// <summary>
+        /// Generates the SQL statements for an alter table command.
+        /// </summary>
+        /// <param name="command">The command to translate.</param>
+        /// <returns>The SQL statements that alter the table.</returns>
         IEnumerable<string> Run(IAlterTableCommand command);
+
+        /// <summary>
+        /// Appends the SQL for an add column command to the provided builder.
+        /// </summary>
+        /// <param name="builder">The builder to append the SQL to.</param>
+        /// <param name="command">The command to translate.</param>
         void Run(StringBuilder builder, IAddColumnCommand command);
+
+        /// <summary>
+        /// Appends the SQL for a drop column command to the provided builder.
+        /// </summary>
+        /// <param name="builder">The builder to append the SQL to.</param>
+        /// <param name="command">The command to translate.</param>
         void Run(StringBuilder builder, IDropColumnCommand command);
+
+        /// <summary>
+        /// Appends the SQL for an alter column command to the provided builder.
+        /// </summary>
+        /// <param name="builder">The builder to append the SQL to.</param>
+        /// <param name="command">The command to translate.</param>
         void Run(StringBuilder builder, IAlterColumnCommand command);
+
+        /// <summary>
+        /// Appends the SQL for an add index command to the provided builder.
+        /// </summary>
+        /// <param name="builder">The builder to append the SQL to.</param>
+        /// <param name="command">The command to translate.</param>
         void Run(StringBuilder builder, IAddIndexCommand command);
+
+        /// <summary>
+        /// Appends the SQL for a drop index command to the provided builder.
+        /// </summary>
+        /// <param name="builder">The builder to append the SQL to.</param>
+        /// <param name="command">The command to translate.</param>
         void Run(StringBuilder builder, IDropIndexCommand command);
+
+        /// <summary>
+        /// Generates the SQL statements for a raw SQL statement command.
+        /// </summary>
+        /// <param name="command">The command to translate.</param>
+        /// <returns>The SQL statements to execute.</returns>
         IEnumerable<string> Run(ISqlStatementCommand command);
+
+        /// <summary>
+        /// Generates the SQL statements for a create foreign key command.
+        /// </summary>
+        /// <param name="command">The command to translate.</param>
+        /// <returns>The SQL statements that create the foreign key.</returns>
         IEnumerable<string> Run(ICreateForeignKeyCommand command);
+
+        /// <summary>
+        /// Generates the SQL statements for a drop foreign key command.
+        /// </summary>
+        /// <param name="command">The command to translate.</param>
+        /// <returns>The SQL statements that drop the foreign key.</returns>
         IEnumerable<string> Run(IDropForeignKeyCommand command);
     }
 }

--- a/src/YesSql.Abstractions/ICompiledQuery.cs
+++ b/src/YesSql.Abstractions/ICompiledQuery.cs
@@ -11,6 +11,10 @@ namespace YesSql
     /// <typeparam name="T">The type of object the query returns.</typeparam>
     public interface ICompiledQuery<T> where T : class
     {
+        /// <summary>
+        /// Gets the expression tree representing the compiled query.
+        /// </summary>
+        /// <returns>An expression that transforms an <see cref="IQuery{T}"/> into the desired query.</returns>
         Expression<Func<IQuery<T>, IQuery<T>>> Query();
     }
 }

--- a/src/YesSql.Abstractions/IConfiguration.cs
+++ b/src/YesSql.Abstractions/IConfiguration.cs
@@ -105,6 +105,9 @@ namespace YesSql
         IdentityColumnSize IdentityColumnSize { get; set; }
     }
 
+    /// <summary>
+    /// Provides extension methods for configuring an <see cref="IConfiguration"/> instance.
+    /// </summary>
     public static class ConfigurationExtensions
     {
         /// <summary>

--- a/src/YesSql.Abstractions/IQuery.cs
+++ b/src/YesSql.Abstractions/IQuery.cs
@@ -7,6 +7,9 @@ using YesSql.Indexes;
 
 namespace YesSql
 {
+    /// <summary>
+    /// Represents an untyped query used to select the document or index type to return.
+    /// </summary>
     public interface IQuery
     {
         /// <summary>
@@ -249,6 +252,9 @@ namespace YesSql
         /// </summary>
         IQuery<T, TIndex> OrderBy(string sql);
 
+        /// <summary>
+        /// Sets a descending OrderBy clause using a custom lambda expression.
+        /// </summary>
         IQuery<T, TIndex> OrderByDescending(Expression<Func<TIndex, object>> keySelector);
 
         /// <summary>

--- a/src/YesSql.Abstractions/ISqlBuilder.cs
+++ b/src/YesSql.Abstractions/ISqlBuilder.cs
@@ -7,44 +7,244 @@ namespace YesSql
     /// </summary>
     public interface ISqlBuilder
     {
+        /// <summary>
+        /// Gets the type of clause being built (for example a select or an update).
+        /// </summary>
         string Clause { get; }
+
+        /// <summary>
+        /// Gets the dictionary of named parameters added to the query.
+        /// </summary>
         Dictionary<string, object> Parameters { get; }
+
+        /// <summary>
+        /// Formats a column reference using the dialect's quoting rules.
+        /// </summary>
+        /// <param name="table">The name of the table the column belongs to.</param>
+        /// <param name="column">The name of the column.</param>
+        /// <param name="schema">The schema the table belongs to.</param>
+        /// <param name="isAlias">If <c>true</c>, the table is treated as an alias rather than a real table name.</param>
+        /// <returns>The formatted column reference.</returns>
         string FormatColumn(string table, string column, string schema, bool isAlias = false);
+
+        /// <summary>
+        /// Formats a table reference using the dialect's quoting rules.
+        /// </summary>
+        /// <param name="table">The name of the table.</param>
+        /// <param name="schema">The schema the table belongs to.</param>
+        /// <returns>The formatted table reference.</returns>
         string FormatTable(string table, string schema);
+
+        /// <summary>
+        /// Gets the current selector clause of the query.
+        /// </summary>
+        /// <returns>The selector clause.</returns>
         string GetSelector();
+
+        /// <summary>
+        /// Gets a value indicating whether the query contains a join.
+        /// </summary>
         bool HasJoin { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the query contains an order clause.
+        /// </summary>
         bool HasOrder { get; }
+
+        /// <summary>
+        /// Removes the group by clause from the query.
+        /// </summary>
         void ClearGroupBy();
+
+        /// <summary>
+        /// Removes the order clause from the query.
+        /// </summary>
         void ClearOrder();
+
+        /// <summary>
+        /// Sets an ascending order clause, replacing any existing one.
+        /// </summary>
+        /// <param name="orderBy">The order by expression.</param>
         void OrderBy(string orderBy);
+
+        /// <summary>
+        /// Sets a descending order clause, replacing any existing one.
+        /// </summary>
+        /// <param name="orderBy">The order by expression.</param>
         void OrderByDescending(string orderBy);
+
+        /// <summary>
+        /// Sets a random order clause, replacing any existing one.
+        /// </summary>
         void OrderByRandom();
+
+        /// <summary>
+        /// Marks the query as a select statement.
+        /// </summary>
         void Select();
+
+        /// <summary>
+        /// Sets the selector clause of the query.
+        /// </summary>
+        /// <param name="selector">The selector expression.</param>
         void Selector(string selector);
+
+        /// <summary>
+        /// Sets the selector clause of the query to a single column.
+        /// </summary>
+        /// <param name="table">The name of the table the column belongs to.</param>
+        /// <param name="column">The name of the column.</param>
+        /// <param name="schema">The schema the table belongs to.</param>
         void Selector(string table, string column, string schema);
+
+        /// <summary>
+        /// Appends an expression to the selector clause of the query.
+        /// </summary>
+        /// <param name="select">The selector expression to add.</param>
         void AddSelector(string select);
+
+        /// <summary>
+        /// Inserts an expression at the beginning of the selector clause of the query.
+        /// </summary>
+        /// <param name="select">The selector expression to insert.</param>
         void InsertSelector(string select);
+
+        /// <summary>
+        /// Marks the selector clause as returning distinct rows.
+        /// </summary>
         void Distinct();
+
+        /// <summary>
+        /// Gets a value indicating whether the query has a paging clause (skip or take).
+        /// </summary>
         bool HasPaging { get; }
+
+        /// <summary>
+        /// Sets the number of rows to skip.
+        /// </summary>
+        /// <param name="skip">The skip expression.</param>
         void Skip(string skip);
+
+        /// <summary>
+        /// Sets the number of rows to take.
+        /// </summary>
+        /// <param name="take">The take expression.</param>
         void Take(string take);
+
+        /// <summary>
+        /// Sets the table the query operates on.
+        /// </summary>
+        /// <param name="table">The name of the table.</param>
+        /// <param name="alias">The alias of the table.</param>
+        /// <param name="schema">The schema the table belongs to.</param>
         void Table(string table, string alias, string schema);
+
+        /// <summary>
+        /// Sets the from clause of the query.
+        /// </summary>
+        /// <param name="from">The from expression.</param>
         void From(string from);
+
+        /// <summary>
+        /// Appends an additional ascending order clause to the query.
+        /// </summary>
+        /// <param name="orderBy">The order by expression.</param>
         void ThenOrderBy(string orderBy);
+
+        /// <summary>
+        /// Appends an additional descending order clause to the query.
+        /// </summary>
+        /// <param name="orderBy">The order by expression.</param>
         void ThenOrderByDescending(string orderBy);
+
+        /// <summary>
+        /// Appends an additional random order clause to the query.
+        /// </summary>
         void ThenOrderByRandom();
+
+        /// <summary>
+        /// Sets the having clause of the query.
+        /// </summary>
+        /// <param name="having">The having expression.</param>
         void Having(string having);
+
+        /// <summary>
+        /// Sets the group by clause of the query.
+        /// </summary>
+        /// <param name="groupBy">The group by expression.</param>
         void GroupBy(string groupBy);
+
+        /// <summary>
+        /// Appends a trailing fragment to the generated SQL.
+        /// </summary>
+        /// <param name="trail">The trailing SQL fragment.</param>
         void Trail(string trail);
+
+        /// <summary>
+        /// Removes the trailing fragment from the generated SQL.
+        /// </summary>
         void ClearTrail();
+
+        /// <summary>
+        /// Builds the SQL string for the current query.
+        /// </summary>
+        /// <returns>The generated SQL statement.</returns>
         string ToSqlString();
+
+        /// <summary>
+        /// Combines the specified clause with the existing where clause using a logical AND.
+        /// </summary>
+        /// <param name="clause">The clause to add.</param>
         void WhereAnd(string clause);
+
+        /// <summary>
+        /// Combines the specified clause with the existing where clause using a logical OR.
+        /// </summary>
+        /// <param name="clause">The clause to add.</param>
         void WhereOr(string clause);
+
+        /// <summary>
+        /// Creates a deep copy of this builder.
+        /// </summary>
+        /// <returns>A new <see cref="ISqlBuilder"/> that is a copy of this instance.</returns>
         ISqlBuilder Clone();
+
+        /// <summary>
+        /// Gets the individual selector expressions of the query.
+        /// </summary>
+        /// <returns>The selector expressions.</returns>
         IEnumerable<string> GetSelectors();
+
+        /// <summary>
+        /// Gets the individual order expressions of the query.
+        /// </summary>
+        /// <returns>The order expressions.</returns>
         IEnumerable<string> GetOrders();
+
+        /// <summary>
+        /// Adds a join between two tables to the query.
+        /// </summary>
+        /// <param name="type">The type of join to add.</param>
+        /// <param name="table">The name of the table to join.</param>
+        /// <param name="onTable">The name of the table that holds the join column.</param>
+        /// <param name="onColumn">The name of the column on the joined table.</param>
+        /// <param name="toTable">The name of the table being joined to.</param>
+        /// <param name="toColumn">The name of the column on the table being joined to.</param>
+        /// <param name="schema">The schema the tables belong to.</param>
+        /// <param name="alias">An optional alias for the joined table.</param>
+        /// <param name="toAlias">An optional alias for the table being joined to.</param>
         void Join(JoinType type, string table, string onTable, string onColumn, string toTable, string toColumn, string schema, string alias = null, string toAlias = null);
+
+        /// <summary>
+        /// Combines the specified clause with the existing having clause using a logical AND.
+        /// </summary>
+        /// <param name="having">The having clause to add.</param>
         void HavingAnd(string having);
+
+        /// <summary>
+        /// Combines the specified clause with the existing having clause using a logical OR.
+        /// </summary>
+        /// <param name="having">The having clause to add.</param>
         void HavingOr(string having);
     }
 }

--- a/src/YesSql.Abstractions/ISqlDialect.cs
+++ b/src/YesSql.Abstractions/ISqlDialect.cs
@@ -5,6 +5,10 @@ using System.Text;
 
 namespace YesSql
 {
+    /// <summary>
+    /// Represents a database-specific SQL dialect, providing type mappings, quoting rules
+    /// and statement generation for a particular database provider.
+    /// </summary>
     public interface ISqlDialect
     {
 
@@ -23,10 +27,24 @@ namespace YesSql
         /// </summary>
         DbType ToDbType(Type type);
 
+        /// <summary>
+        /// Converts a value to the representation expected by the database, using the registered type handlers.
+        /// </summary>
+        /// <param name="source">The value to convert.</param>
+        /// <returns>The converted value, or the original value when no conversion applies.</returns>
         object TryConvert(object source);
 
+        /// <summary>
+        /// Removes all the registered custom type handlers.
+        /// </summary>
         void ResetTypeHandlers();
 
+        /// <summary>
+        /// Registers a custom handler that converts a value of type <typeparamref name="T"/> before it is sent to the database.
+        /// </summary>
+        /// <typeparam name="T">The .NET type to handle.</typeparam>
+        /// <typeparam name="TU">The type the value is converted to.</typeparam>
+        /// <param name="handler">The conversion delegate.</param>
         void AddTypeHandler<T, TU>(Func<T, TU> handler);
 
         /// <summary>

--- a/src/YesSql.Abstractions/IStore.cs
+++ b/src/YesSql.Abstractions/IStore.cs
@@ -6,6 +6,9 @@ using YesSql.Indexes;
 
 namespace YesSql
 {
+    /// <summary>
+    /// Represents a document store that creates sessions and manages the underlying database schema and configuration.
+    /// </summary>
     public interface IStore : IDisposable
     {
         /// <summary>

--- a/src/YesSql.Abstractions/IStringBuilder.cs
+++ b/src/YesSql.Abstractions/IStringBuilder.cs
@@ -4,23 +4,98 @@ using System;
 
 namespace YesSql
 {
+    /// <summary>
+    /// Represents a mutable string buffer used to build SQL statements efficiently.
+    /// </summary>
     public interface IStringBuilder
     {
+        /// <summary>
+        /// Gets a reference to the character at the specified index.
+        /// </summary>
+        /// <param name="index">The zero-based index of the character.</param>
         ref char this[int index] { get; }
 
+        /// <summary>
+        /// Gets the number of characters that can be stored before the buffer needs to grow.
+        /// </summary>
         int Capacity { get; }
+
+        /// <summary>
+        /// Gets or sets the number of characters currently in the buffer.
+        /// </summary>
         int Length { get; set; }
 
+        /// <summary>
+        /// Appends a span of characters to the end of the buffer.
+        /// </summary>
+        /// <param name="value">The characters to append.</param>
         void Append(ReadOnlySpan<char> value);
+
+        /// <summary>
+        /// Appends a string to the end of the buffer.
+        /// </summary>
+        /// <param name="s">The string to append.</param>
         void Append(string s);
+
+        /// <summary>
+        /// Returns a span over the entire content of the buffer.
+        /// </summary>
+        /// <returns>A span over the buffer content.</returns>
         ReadOnlySpan<char> AsSpan();
+
+        /// <summary>
+        /// Returns a span over the content of the buffer starting at the specified position.
+        /// </summary>
+        /// <param name="start">The zero-based starting position.</param>
+        /// <returns>A span over the buffer content from <paramref name="start"/>.</returns>
         ReadOnlySpan<char> AsSpan(int start);
+
+        /// <summary>
+        /// Returns a span over a range of the content of the buffer.
+        /// </summary>
+        /// <param name="start">The zero-based starting position.</param>
+        /// <param name="length">The number of characters in the span.</param>
+        /// <returns>A span over the requested range of the buffer content.</returns>
         ReadOnlySpan<char> AsSpan(int start, int length);
+
+        /// <summary>
+        /// Removes all characters from the buffer.
+        /// </summary>
         void Clear();
+
+        /// <summary>
+        /// Ensures the buffer can hold at least the specified number of characters without growing.
+        /// </summary>
+        /// <param name="capacity">The minimum capacity to ensure.</param>
         void EnsureCapacity(int capacity);
+
+        /// <summary>
+        /// Inserts a character repeated a number of times at the specified position.
+        /// </summary>
+        /// <param name="index">The zero-based position to insert at.</param>
+        /// <param name="value">The character to insert.</param>
+        /// <param name="count">The number of times to insert the character.</param>
         void Insert(int index, char value, int count);
+
+        /// <summary>
+        /// Inserts a string at the specified position.
+        /// </summary>
+        /// <param name="index">The zero-based position to insert at.</param>
+        /// <param name="s">The string to insert.</param>
         void Insert(int index, string s);
+
+        /// <summary>
+        /// Returns the content of the buffer as a string.
+        /// </summary>
+        /// <returns>The buffer content.</returns>
         string ToString();
+
+        /// <summary>
+        /// Attempts to copy the content of the buffer to the destination span.
+        /// </summary>
+        /// <param name="destination">The span to copy the content to.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters written.</param>
+        /// <returns><c>true</c> if the content was copied successfully; otherwise, <c>false</c>.</returns>
         bool TryCopyTo(Span<char> destination, out int charsWritten);
     }
 }

--- a/src/YesSql.Abstractions/IdentityColumnSize.cs
+++ b/src/YesSql.Abstractions/IdentityColumnSize.cs
@@ -1,8 +1,18 @@
 namespace YesSql
 {
+    /// <summary>
+    /// Defines the size of an identity column.
+    /// </summary>
     public enum IdentityColumnSize
     {
+        /// <summary>
+        /// A 32-bit (<see cref="int"/>) identity column.
+        /// </summary>
         Int32 = 1,
+
+        /// <summary>
+        /// A 64-bit (<see cref="long"/>) identity column.
+        /// </summary>
         Int64 = 2
     }
 }

--- a/src/YesSql.Abstractions/Indexes/DescribeContext.cs
+++ b/src/YesSql.Abstractions/Indexes/DescribeContext.cs
@@ -4,10 +4,20 @@ using System.Linq;
 
 namespace YesSql.Indexes
 {
+    /// <summary>
+    /// Provides the context used by an <see cref="IIndexProvider"/> to describe how
+    /// indexes are mapped, grouped and reduced for documents of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the document the indexes are described for.</typeparam>
     public class DescribeContext<T> : IDescriptor
     {
         private readonly Dictionary<Type, List<IDescribeFor>> _describes = new Dictionary<Type, List<IDescribeFor>>();
 
+        /// <summary>
+        /// Builds the <see cref="IndexDescriptor"/> instances for the described indexes.
+        /// </summary>
+        /// <param name="types">The index types to describe, or an empty array to describe all of them.</param>
+        /// <returns>The descriptors matching the requested index types.</returns>
         public IEnumerable<IndexDescriptor> Describe(params Type[] types)
         {
             return _describes
@@ -25,11 +35,23 @@ namespace YesSql.Indexes
                 });
         }
 
+        /// <summary>
+        /// Starts describing how an index of type <typeparamref name="TIndex"/> is built from the document.
+        /// </summary>
+        /// <typeparam name="TIndex">The type of the index to map.</typeparam>
+        /// <returns>An <see cref="IMapFor{T, TIndex}"/> used to configure the mapping.</returns>
         public IMapFor<T, TIndex> For<TIndex>() where TIndex : IIndex
         {
             return For<TIndex, object>();
         }
 
+        /// <summary>
+        /// Starts describing how an index of type <typeparamref name="TIndex"/> with a group key of
+        /// type <typeparamref name="TKey"/> is built from the document.
+        /// </summary>
+        /// <typeparam name="TIndex">The type of the index to map.</typeparam>
+        /// <typeparam name="TKey">The type of the key used to group reduce indexes.</typeparam>
+        /// <returns>An <see cref="IMapFor{T, TIndex}"/> used to configure the mapping.</returns>
         public IMapFor<T, TIndex> For<TIndex, TKey>() where TIndex : IIndex
         {
             if (!_describes.TryGetValue(typeof(T), out var descriptors))

--- a/src/YesSql.Abstractions/Indexes/DescribeFor.cs
+++ b/src/YesSql.Abstractions/Indexes/DescribeFor.cs
@@ -9,42 +9,152 @@ using System.Threading.Tasks;
 
 namespace YesSql.Indexes
 {
+    /// <summary>
+    /// Describes how an index is mapped, grouped, reduced and deleted for a document type.
+    /// </summary>
     public interface IDescribeFor
     {
+        /// <summary>
+        /// Gets the delegate that maps a document to a set of indexes.
+        /// </summary>
+        /// <returns>A delegate producing the indexes for a given document.</returns>
         Func<object, CancellationToken, Task<IEnumerable<IIndex>>> GetMap();
+
+        /// <summary>
+        /// Gets the delegate that reduces a group of indexes into a single index.
+        /// </summary>
+        /// <returns>A delegate reducing a grouping of indexes, or <c>null</c> when no reduction is defined.</returns>
         Func<IGrouping<object, IIndex>, IIndex> GetReduce();
+
+        /// <summary>
+        /// Gets the delegate that computes the index to delete from a reduced group.
+        /// </summary>
+        /// <returns>A delegate producing the index to delete, or <c>null</c> when no deletion is defined.</returns>
         Func<IIndex, IEnumerable<IIndex>, IIndex> GetDelete();
+
+        /// <summary>
+        /// Gets or sets the property used to group indexes when reducing.
+        /// </summary>
         PropertyInfo GroupProperty { get; set; }
+
+        /// <summary>
+        /// Gets the type of the index that is described.
+        /// </summary>
         Type IndexType { get; }
+
+        /// <summary>
+        /// Gets the predicate used to filter the documents that are mapped, or <c>null</c> when no filter is defined.
+        /// </summary>
         Func<object, bool> Filter { get; }
     }
 
+    /// <summary>
+    /// Configures the mapping of a document of type <typeparamref name="T"/> to an index of type <typeparamref name="TIndex"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the document to map.</typeparam>
+    /// <typeparam name="TIndex">The type of the index to produce.</typeparam>
     public interface IMapFor<out T, TIndex> where TIndex : IIndex
     {
+        /// <summary>
+        /// Maps a document to a single index.
+        /// </summary>
+        /// <param name="map">A delegate producing an index from a document.</param>
+        /// <returns>An <see cref="IGroupFor{TIndex}"/> used to optionally group the index.</returns>
         IGroupFor<TIndex> Map(Func<T, TIndex> map);
+
+        /// <summary>
+        /// Maps a document to a set of indexes.
+        /// </summary>
+        /// <param name="map">A delegate producing indexes from a document.</param>
+        /// <returns>An <see cref="IGroupFor{TIndex}"/> used to optionally group the indexes.</returns>
         IGroupFor<TIndex> Map(Func<T, IEnumerable<TIndex>> map);
+
+        /// <summary>
+        /// Maps a document to a single index asynchronously.
+        /// </summary>
+        /// <param name="map">A delegate asynchronously producing an index from a document.</param>
+        /// <returns>An <see cref="IGroupFor{TIndex}"/> used to optionally group the index.</returns>
         IGroupFor<TIndex> Map(Func<T, Task<TIndex>> map);
+
+        /// <summary>
+        /// Maps a document to a single index asynchronously.
+        /// </summary>
+        /// <param name="map">A delegate asynchronously producing an index from a document, honoring a cancellation token.</param>
+        /// <returns>An <see cref="IGroupFor{TIndex}"/> used to optionally group the index.</returns>
         IGroupFor<TIndex> Map(Func<T, CancellationToken, Task<TIndex>> map);
+
+        /// <summary>
+        /// Maps a document to a set of indexes asynchronously.
+        /// </summary>
+        /// <param name="map">A delegate asynchronously producing indexes from a document.</param>
+        /// <returns>An <see cref="IGroupFor{TIndex}"/> used to optionally group the indexes.</returns>
         IGroupFor<TIndex> Map(Func<T, Task<IEnumerable<TIndex>>> map);
+
+        /// <summary>
+        /// Maps a document to a set of indexes asynchronously.
+        /// </summary>
+        /// <param name="map">A delegate asynchronously producing indexes from a document, honoring a cancellation token.</param>
+        /// <returns>An <see cref="IGroupFor{TIndex}"/> used to optionally group the indexes.</returns>
         IGroupFor<TIndex> Map(Func<T, CancellationToken, Task<IEnumerable<TIndex>>> map);
+
+        /// <summary>
+        /// Restricts the mapping to the documents that satisfy the specified predicate.
+        /// </summary>
+        /// <param name="predicate">The predicate a document must satisfy to be mapped.</param>
+        /// <returns>The current <see cref="IMapFor{T, TIndex}"/> instance so that calls can be chained.</returns>
         IMapFor<T, TIndex> When(Func<T, bool> predicate);
     }
 
+    /// <summary>
+    /// Configures how mapped indexes of type <typeparamref name="TIndex"/> are grouped before being reduced.
+    /// </summary>
+    /// <typeparam name="TIndex">The type of the index to group.</typeparam>
     public interface IGroupFor<TIndex> where TIndex : IIndex
     {
+        /// <summary>
+        /// Groups the mapped indexes by the specified key.
+        /// </summary>
+        /// <typeparam name="TKey">The type of the grouping key.</typeparam>
+        /// <param name="group">An expression selecting the property used as the grouping key.</param>
+        /// <returns>An <see cref="IReduceFor{TIndex, TKey}"/> used to configure the reduction.</returns>
         IReduceFor<TIndex, TKey> Group<TKey>(Expression<Func<TIndex, TKey>> group);
     }
 
+    /// <summary>
+    /// Configures how a group of indexes of type <typeparamref name="TIndex"/> is reduced into a single index.
+    /// </summary>
+    /// <typeparam name="TIndex">The type of the index to reduce.</typeparam>
+    /// <typeparam name="TKey">The type of the grouping key.</typeparam>
     public interface IReduceFor<TIndex, out TKey> where TIndex : IIndex
     {
+        /// <summary>
+        /// Reduces a group of indexes into a single index.
+        /// </summary>
+        /// <param name="reduce">A delegate producing the reduced index from a grouping.</param>
+        /// <returns>An <see cref="IDeleteFor{TIndex}"/> used to configure how the reduced index is deleted.</returns>
         IDeleteFor<TIndex> Reduce(Func<IGrouping<TKey, TIndex>, TIndex> reduce);
     }
 
+    /// <summary>
+    /// Configures how a reduced index of type <typeparamref name="TIndex"/> is updated when documents are removed.
+    /// </summary>
+    /// <typeparam name="TIndex">The type of the index being deleted.</typeparam>
     public interface IDeleteFor<TIndex> where TIndex : IIndex
     {
+        /// <summary>
+        /// Defines how a reduced index is recomputed when documents are removed from its group.
+        /// </summary>
+        /// <param name="delete">A delegate producing the updated index, or <c>null</c> to remove the index entirely.</param>
         void Delete(Func<TIndex, IEnumerable<TIndex>, TIndex> delete = null);
     }
 
+    /// <summary>
+    /// Default implementation of the index description fluent interfaces, capturing the map,
+    /// group, reduce and delete delegates for an index of type <typeparamref name="TIndex"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the document to map.</typeparam>
+    /// <typeparam name="TIndex">The type of the index to produce.</typeparam>
+    /// <typeparam name="TKey">The type of the grouping key.</typeparam>
     public class IndexDescriptor<T, TIndex, TKey> : IDescribeFor, IMapFor<T, TIndex>, IGroupFor<TIndex>, IReduceFor<TIndex, TKey>, IDeleteFor<TIndex> where TIndex : IIndex
     {
         private Func<T, CancellationToken, Task<IEnumerable<TIndex>>> _map;
@@ -53,47 +163,58 @@ namespace YesSql.Indexes
         private IDescribeFor _reduceDescribeFor;
         private Func<object, bool> _filter;
 
+        /// <inheritdoc/>
         public PropertyInfo GroupProperty { get; set; }
+
+        /// <inheritdoc/>
         public Type IndexType => typeof(TIndex);
 
+        /// <inheritdoc/>
         public Func<object, bool> Filter => _filter;
 
+        /// <inheritdoc/>
         public IGroupFor<TIndex> Map(Func<T, IEnumerable<TIndex>> map)
         {
             _map = (x, token) => Task.FromResult(map(x));
             return this;
         }
 
+        /// <inheritdoc/>
         public IMapFor<T, TIndex> When(Func<T, bool> predicate)
         {
             _filter = x => predicate((T)x);
             return this;
         }
 
+        /// <inheritdoc/>
         public IGroupFor<TIndex> Map(Func<T, TIndex> map)
         {
             _map = (x, token) => Task.FromResult((IEnumerable<TIndex>)new[] { map(x) });
             return this;
         }
 
+        /// <inheritdoc/>
         public IGroupFor<TIndex> Map(Func<T, Task<IEnumerable<TIndex>>> map)
         {
             _map = async (x,token) => await map(x);
             return this;
         }
 
+        /// <inheritdoc/>
         public IGroupFor<TIndex> Map(Func<T, CancellationToken, Task<IEnumerable<TIndex>>> map)
         {
             _map = map;
             return this;
         }
 
+        /// <inheritdoc/>
         public IGroupFor<TIndex> Map(Func<T,  Task<TIndex>> map)
         {
             _map = async (x, token) => new[] { await map(x) };
             return this;
         }
 
+        /// <inheritdoc/>
         public IGroupFor<TIndex> Map(Func<T, CancellationToken, Task<TIndex>> map)
         {
             _map = async (x, token) => new[] { await map(x, token) };
@@ -101,6 +222,7 @@ namespace YesSql.Indexes
         }
 
 
+        /// <inheritdoc/>
         public IReduceFor<TIndex, TKeyG> Group<TKeyG>(Expression<Func<TIndex, TKeyG>> group)
         {
             var memberExpression = group.Body as MemberExpression
@@ -117,12 +239,14 @@ namespace YesSql.Indexes
             return reduceDescribeFor;
         }
 
+        /// <inheritdoc/>
         public IDeleteFor<TIndex> Reduce(Func<IGrouping<TKey, TIndex>, TIndex> reduce)
         {
             _reduce = reduce;
             return this;
         }
 
+        /// <inheritdoc/>
         public void Delete(Func<TIndex, IEnumerable<TIndex>, TIndex> delete = null)
         {
             _delete = delete;
@@ -163,19 +287,36 @@ namespace YesSql.Indexes
         }
     }
 
+    /// <summary>
+    /// Represents a grouping of indexes of type <typeparamref name="TIndex"/> sharing the same key.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the grouping key.</typeparam>
+    /// <typeparam name="TIndex">The type of the grouped indexes.</typeparam>
     public class GroupedEnumerable<TKey, TIndex> : IGrouping<TKey, TIndex> where TIndex : IIndex
     {
         private readonly object _key;
         private readonly IEnumerable<IIndex> _enumerable;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GroupedEnumerable{TKey, TIndex}"/> class.
+        /// </summary>
+        /// <param name="key">The key shared by the indexes in the group.</param>
+        /// <param name="enumerable">The indexes that belong to the group.</param>
         public GroupedEnumerable(object key, IEnumerable<IIndex> enumerable)
         {
             _key = key;
             _enumerable = enumerable;
         }
 
+        /// <summary>
+        /// Gets the key shared by all the indexes in the group.
+        /// </summary>
         public TKey Key => (TKey)_key;
 
+        /// <summary>
+        /// Returns an enumerator that iterates through the indexes in the group.
+        /// </summary>
+        /// <returns>An enumerator for the grouped indexes.</returns>
         public IEnumerator<TIndex> GetEnumerator()
         {
             return _enumerable.Cast<TIndex>().GetEnumerator();

--- a/src/YesSql.Abstractions/Indexes/IDescriptor.cs
+++ b/src/YesSql.Abstractions/Indexes/IDescriptor.cs
@@ -3,8 +3,16 @@ using System.Collections.Generic;
 
 namespace YesSql.Indexes
 {
+    /// <summary>
+    /// Describes the indexes that an <see cref="IIndexProvider"/> produces for a document type.
+    /// </summary>
     public interface IDescriptor
     {
+        /// <summary>
+        /// Builds the <see cref="IndexDescriptor"/> instances for the described indexes.
+        /// </summary>
+        /// <param name="types">The index types to describe, or an empty array to describe all of them.</param>
+        /// <returns>The descriptors matching the requested index types.</returns>
         IEnumerable<IndexDescriptor> Describe(params Type[] types);
     }
 }

--- a/src/YesSql.Abstractions/Indexes/IIndex.cs
+++ b/src/YesSql.Abstractions/Indexes/IIndex.cs
@@ -2,12 +2,38 @@ using System.Collections.Generic;
 
 namespace YesSql.Indexes
 {
+    /// <summary>
+    /// Represents an index entry associated with one or more documents in the store.
+    /// </summary>
     public interface IIndex
     {
+        /// <summary>
+        /// Gets or sets the unique identifier of the index record.
+        /// </summary>
         long Id { get; set; }
+
+        /// <summary>
+        /// Associates a document with this index.
+        /// </summary>
+        /// <param name="document">The document to add.</param>
         void AddDocument(Document document);
+
+        /// <summary>
+        /// Removes the association between a document and this index.
+        /// </summary>
+        /// <param name="document">The document to remove.</param>
         void RemoveDocument(Document document);
+
+        /// <summary>
+        /// Gets the documents that have been associated with this index.
+        /// </summary>
+        /// <returns>The added documents.</returns>
         IEnumerable<Document> GetAddedDocuments();
+
+        /// <summary>
+        /// Gets the documents that have been removed from this index.
+        /// </summary>
+        /// <returns>The removed documents.</returns>
         IEnumerable<Document> GetRemovedDocuments();
     }
 }

--- a/src/YesSql.Abstractions/Indexes/IIndexProvider.cs
+++ b/src/YesSql.Abstractions/Indexes/IIndexProvider.cs
@@ -2,10 +2,27 @@
 
 namespace YesSql.Indexes
 {
+    /// <summary>
+    /// Provides the index descriptions for a given document type so the store can
+    /// maintain the corresponding index tables.
+    /// </summary>
     public interface IIndexProvider
     {
+        /// <summary>
+        /// Describes the indexes produced for the document type handled by this provider.
+        /// </summary>
+        /// <param name="context">The descriptor context to populate.</param>
         void Describe(IDescriptor context);
+
+        /// <summary>
+        /// Gets the document type that this provider creates indexes for.
+        /// </summary>
+        /// <returns>The document type.</returns>
         Type ForType();
+
+        /// <summary>
+        /// Gets or sets the name of the collection the provider applies to.
+        /// </summary>
         string CollectionName { get; set; }
     }
 }

--- a/src/YesSql.Abstractions/Indexes/IndexDescriptor.cs
+++ b/src/YesSql.Abstractions/Indexes/IndexDescriptor.cs
@@ -7,15 +7,50 @@ using System.Threading.Tasks;
 
 namespace YesSql.Indexes
 {
+    /// <summary>
+    /// Holds the delegates and metadata that define how an index is mapped, grouped,
+    /// reduced, updated and deleted for a document type.
+    /// </summary>
     public class IndexDescriptor
     {
+        /// <summary>
+        /// Gets or sets the document type the index is built from.
+        /// </summary>
         public Type Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the delegate that maps a document to a set of indexes.
+        /// </summary>
         public Func<object, CancellationToken, Task<IEnumerable<IIndex>>> Map { get; set; }
+
+        /// <summary>
+        /// Gets or sets the delegate that reduces a group of indexes into a single index.
+        /// </summary>
         public Func<IGrouping<object, IIndex>, IIndex> Reduce { get; set; }
+
+        /// <summary>
+        /// Gets or sets the delegate that updates a reduced index when documents are added.
+        /// </summary>
         public Func<IIndex, IEnumerable<IIndex>, IIndex> Update { get; set; }
+
+        /// <summary>
+        /// Gets or sets the delegate that updates a reduced index when documents are removed.
+        /// </summary>
         public Func<IIndex, IEnumerable<IIndex>, IIndex> Delete { get; set; }
+
+        /// <summary>
+        /// Gets or sets the property used to group indexes when reducing.
+        /// </summary>
         public PropertyInfo GroupKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of the index that is described.
+        /// </summary>
         public Type IndexType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the predicate used to filter the documents that are mapped.
+        /// </summary>
         public Func<object, bool> Filter { get; set; }
     }
 }

--- a/src/YesSql.Abstractions/Indexes/IndexProvider.cs
+++ b/src/YesSql.Abstractions/Indexes/IndexProvider.cs
@@ -2,8 +2,16 @@
 
 namespace YesSql.Indexes
 {
+    /// <summary>
+    /// A base class for index providers that describe the indexes for documents of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The document type the indexes are produced for.</typeparam>
     public abstract class IndexProvider<T> : IIndexProvider
     {
+        /// <summary>
+        /// Describes the indexes produced for documents of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="context">The strongly typed descriptor context to populate.</param>
         public abstract void Describe(DescribeContext<T> context);
 
         void IIndexProvider.Describe(IDescriptor context)
@@ -11,8 +19,15 @@ namespace YesSql.Indexes
             Describe((DescribeContext<T>)context);
         }
 
+        /// <summary>
+        /// Gets or sets the name of the collection the provider applies to.
+        /// </summary>
         public string CollectionName { get; set; }
 
+        /// <summary>
+        /// Gets the document type that this provider creates indexes for.
+        /// </summary>
+        /// <returns>The document type <typeparamref name="T"/>.</returns>
         public Type ForType() => typeof(T);
     }
 }

--- a/src/YesSql.Abstractions/Indexes/MapIndex.cs
+++ b/src/YesSql.Abstractions/Indexes/MapIndex.cs
@@ -2,10 +2,16 @@ using System.Collections.Generic;
 
 namespace YesSql.Indexes
 {
+    /// <summary>
+    /// A base class for map indexes, which associate a single document with one index record.
+    /// </summary>
     public abstract class MapIndex : IIndex
     {
         private Document _document;
 
+        /// <summary>
+        /// Gets or sets the unique identifier of the index record.
+        /// </summary>
         public long Id { get; set; }
 
         void IIndex.AddDocument(Document document)

--- a/src/YesSql.Abstractions/Indexes/ReduceIndex.cs
+++ b/src/YesSql.Abstractions/Indexes/ReduceIndex.cs
@@ -2,11 +2,17 @@ using System.Collections.Generic;
 
 namespace YesSql.Indexes
 {
+    /// <summary>
+    /// A base class for reduce indexes, which aggregate multiple documents into a single index record.
+    /// </summary>
     public class ReduceIndex : IIndex
     {
         private readonly List<Document> _removedDocuments = new();
         private readonly List<Document> _documents = new();
         
+        /// <summary>
+        /// Gets or sets the unique identifier of the index record.
+        /// </summary>
         public long Id { get; set; }
 
         void IIndex.AddDocument(Document document)

--- a/src/YesSql.Abstractions/JoinType.cs
+++ b/src/YesSql.Abstractions/JoinType.cs
@@ -1,8 +1,22 @@
 namespace YesSql;
 
+/// <summary>
+/// Defines the type of join used when combining index tables in a query.
+/// </summary>
 public enum JoinType
 {
+    /// <summary>
+    /// An inner join, returning only rows that match in both tables.
+    /// </summary>
     Inner = 0,
+
+    /// <summary>
+    /// A left outer join, returning all rows from the left table.
+    /// </summary>
     Left = 1,
+
+    /// <summary>
+    /// A right outer join, returning all rows from the right table.
+    /// </summary>
     Right = 2
 }

--- a/src/YesSql.Abstractions/QueryExtensions.cs
+++ b/src/YesSql.Abstractions/QueryExtensions.cs
@@ -4,6 +4,9 @@ using YesSql.Indexes;
 
 namespace YesSql
 {
+    /// <summary>
+    /// Provides extension methods for creating queries from an <see cref="ISession"/>.
+    /// </summary>
     public static class QueryExtensions
     {
         /// <summary>

--- a/src/YesSql.Abstractions/SchemaBuilderExtensions.cs
+++ b/src/YesSql.Abstractions/SchemaBuilderExtensions.cs
@@ -5,23 +5,70 @@ using YesSql.Sql.Schema;
 
 namespace YesSql.Sql
 {
+    /// <summary>
+    /// Provides extension methods for building database schemas using strongly typed index types.
+    /// </summary>
     public static class SchemaBuilderExtensions
     {
+        /// <summary>
+        /// Generates the SQL statements for a single schema command.
+        /// </summary>
+        /// <param name="builder">The command interpreter that translates the command.</param>
+        /// <param name="command">The schema command to translate.</param>
+        /// <returns>The SQL statements that implement the command.</returns>
         public static IEnumerable<string> CreateSql(this ICommandInterpreter builder, ISchemaCommand command)
             => builder.CreateSql(new[] { command });
 
+        /// <summary>
+        /// Creates the table that backs the reduce index of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The reduce index type.</typeparam>
+        /// <param name="builder">The schema builder.</param>
+        /// <param name="table">A delegate used to configure the table columns.</param>
+        /// <param name="collection">The name of the collection the index belongs to.</param>
+        /// <returns>A task that completes when the table has been created.</returns>
         public static Task CreateReduceIndexTableAsync<T>(this ISchemaBuilder builder, Action<ICreateTableCommand> table, string collection = null)
             => builder.CreateReduceIndexTableAsync(typeof(T), table, collection);
 
+        /// <summary>
+        /// Drops the table that backs the reduce index of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The reduce index type.</typeparam>
+        /// <param name="builder">The schema builder.</param>
+        /// <param name="collection">The name of the collection the index belongs to.</param>
+        /// <returns>A task that completes when the table has been dropped.</returns>
         public static Task DropReduceIndexTableAsync<T>(this ISchemaBuilder builder, string collection = null)
             => builder.DropReduceIndexTableAsync(typeof(T), collection);
 
+        /// <summary>
+        /// Creates the table that backs the map index of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The map index type.</typeparam>
+        /// <param name="builder">The schema builder.</param>
+        /// <param name="table">A delegate used to configure the table columns.</param>
+        /// <param name="collection">The name of the collection the index belongs to.</param>
+        /// <returns>A task that completes when the table has been created.</returns>
         public static Task CreateMapIndexTableAsync<T>(this ISchemaBuilder builder, Action<ICreateTableCommand> table, string collection = null)
             => builder.CreateMapIndexTableAsync(typeof(T), table, collection);
 
+        /// <summary>
+        /// Drops the table that backs the map index of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The map index type.</typeparam>
+        /// <param name="builder">The schema builder.</param>
+        /// <param name="collection">The name of the collection the index belongs to.</param>
+        /// <returns>A task that completes when the table has been dropped.</returns>
         public static Task DropMapIndexTableAsync<T>(this ISchemaBuilder builder, string collection = null)
             => builder.DropMapIndexTableAsync(typeof(T), collection);
 
+        /// <summary>
+        /// Alters the table that backs the index of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The index type.</typeparam>
+        /// <param name="builder">The schema builder.</param>
+        /// <param name="table">A delegate used to configure the table changes.</param>
+        /// <param name="collection">The name of the collection the index belongs to.</param>
+        /// <returns>A task that completes when the table has been altered.</returns>
         public static Task AlterIndexTableAsync<T>(this ISchemaBuilder builder, Action<IAlterTableCommand> table, string collection = null)
             => builder.AlterIndexTableAsync(typeof(T), table, collection);
     }

--- a/src/YesSql.Abstractions/SessionExtensions.cs
+++ b/src/YesSql.Abstractions/SessionExtensions.cs
@@ -7,6 +7,9 @@ using YesSql.Indexes;
 
 namespace YesSql
 {
+    /// <summary>
+    /// Provides extension methods for working with an <see cref="ISession"/>.
+    /// </summary>
     public static class SessionExtensions
     {
         /// <summary>

--- a/src/YesSql.Abstractions/SimplifiedTypeNameAttribute.cs
+++ b/src/YesSql.Abstractions/SimplifiedTypeNameAttribute.cs
@@ -8,8 +8,15 @@ namespace YesSql
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Delegate)]
     public class SimplifiedTypeNameAttribute : Attribute
     {
+        /// <summary>
+        /// Gets or sets the custom name to use for the type.
+        /// </summary>
         public string Name { get; set; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SimplifiedTypeNameAttribute"/> class.
+        /// </summary>
+        /// <param name="name">The custom name to use for the type.</param>
         public SimplifiedTypeNameAttribute(string name)
         {
             Name = name;

--- a/src/YesSql.Abstractions/SqlBuilderExtensions.cs
+++ b/src/YesSql.Abstractions/SqlBuilderExtensions.cs
@@ -1,13 +1,52 @@
 namespace YesSql;
 
+/// <summary>
+/// Provides extension methods for adding joins to an <see cref="ISqlBuilder"/>.
+/// </summary>
 public static class SqlBuilderExtensions
 {
+    /// <summary>
+    /// Adds an inner join between two tables to the query.
+    /// </summary>
+    /// <param name="builder">The SQL builder to add the join to.</param>
+    /// <param name="table">The name of the table to join.</param>
+    /// <param name="onTable">The name of the table that holds the join column.</param>
+    /// <param name="onColumn">The name of the column on the joined table.</param>
+    /// <param name="toTable">The name of the table being joined to.</param>
+    /// <param name="toColumn">The name of the column on the table being joined to.</param>
+    /// <param name="schema">The schema the tables belong to.</param>
+    /// <param name="alias">An optional alias for the joined table.</param>
+    /// <param name="toAlias">An optional alias for the table being joined to.</param>
     public static void InnerJoin(this ISqlBuilder builder, string table, string onTable, string onColumn, string toTable, string toColumn, string schema, string alias = null, string toAlias = null)
         => builder.Join(JoinType.Inner, table, onTable, onColumn, toTable, toColumn, schema, alias, toAlias);
 
+    /// <summary>
+    /// Adds a left outer join between two tables to the query.
+    /// </summary>
+    /// <param name="builder">The SQL builder to add the join to.</param>
+    /// <param name="table">The name of the table to join.</param>
+    /// <param name="onTable">The name of the table that holds the join column.</param>
+    /// <param name="onColumn">The name of the column on the joined table.</param>
+    /// <param name="toTable">The name of the table being joined to.</param>
+    /// <param name="toColumn">The name of the column on the table being joined to.</param>
+    /// <param name="schema">The schema the tables belong to.</param>
+    /// <param name="alias">An optional alias for the joined table.</param>
+    /// <param name="toAlias">An optional alias for the table being joined to.</param>
     public static void LeftJoin(this ISqlBuilder builder, string table, string onTable, string onColumn, string toTable, string toColumn, string schema, string alias = null, string toAlias = null)
         => builder.Join(JoinType.Left, table, onTable, onColumn, toTable, toColumn, schema, alias, toAlias);
 
+    /// <summary>
+    /// Adds a right outer join between two tables to the query.
+    /// </summary>
+    /// <param name="builder">The SQL builder to add the join to.</param>
+    /// <param name="table">The name of the table to join.</param>
+    /// <param name="onTable">The name of the table that holds the join column.</param>
+    /// <param name="onColumn">The name of the column on the joined table.</param>
+    /// <param name="toTable">The name of the table being joined to.</param>
+    /// <param name="toColumn">The name of the column on the table being joined to.</param>
+    /// <param name="schema">The schema the tables belong to.</param>
+    /// <param name="alias">An optional alias for the joined table.</param>
+    /// <param name="toAlias">An optional alias for the table being joined to.</param>
     public static void RightJoin(this ISqlBuilder builder, string table, string onTable, string onColumn, string toTable, string toColumn, string schema, string alias = null, string toAlias = null)
         => builder.Join(JoinType.Right, table, onTable, onColumn, toTable, toColumn, schema, alias, toAlias);
 }

--- a/src/YesSql.Abstractions/Storage/DocumentIdentity.cs
+++ b/src/YesSql.Abstractions/Storage/DocumentIdentity.cs
@@ -2,8 +2,16 @@ using System;
 
 namespace YesSql.Storage
 {
+    /// <summary>
+    /// Associates an entity with its document identifier and type.
+    /// </summary>
     public class DocumentIdentity : IIdentityEntity
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DocumentIdentity"/> class for an existing entity.
+        /// </summary>
+        /// <param name="id">The unique identifier of the document.</param>
+        /// <param name="entity">The entity instance.</param>
         public DocumentIdentity(long id, object entity)
         {
             Id = id;
@@ -11,6 +19,11 @@ namespace YesSql.Storage
             EntityType = entity.GetType();
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DocumentIdentity"/> class for an entity that has not been loaded yet.
+        /// </summary>
+        /// <param name="id">The unique identifier of the document.</param>
+        /// <param name="type">The type of the entity.</param>
         public DocumentIdentity(long id, Type type)
         {
             Id = id;
@@ -18,8 +31,19 @@ namespace YesSql.Storage
             EntityType = type;
         }
 
+        /// <summary>
+        /// Gets or sets the unique identifier of the document.
+        /// </summary>
         public long Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the entity instance, or <c>null</c> when it has not been loaded.
+        /// </summary>
         public object Entity { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of the entity.
+        /// </summary>
         public Type EntityType { get; set; }
     }
 }

--- a/src/YesSql.Abstractions/Storage/IIdentityEntity.cs
+++ b/src/YesSql.Abstractions/Storage/IIdentityEntity.cs
@@ -2,10 +2,24 @@ using System;
 
 namespace YesSql.Storage
 {
+    /// <summary>
+    /// Represents an entity tracked by the storage layer together with its identifier and type.
+    /// </summary>
     public interface IIdentityEntity
     {
+        /// <summary>
+        /// Gets or sets the unique identifier of the document.
+        /// </summary>
         long Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the entity instance.
+        /// </summary>
         object Entity { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of the entity.
+        /// </summary>
         Type EntityType { get; set; }
     }
 }

--- a/src/YesSql.Filters.Abstractions/Builders/BooleanEngineBuilder.cs
+++ b/src/YesSql.Filters.Abstractions/Builders/BooleanEngineBuilder.cs
@@ -5,9 +5,17 @@ using static Parlot.Fluent.Parsers;
 
 namespace YesSql.Filters.Builders
 {
+    /// <summary>
+    /// Builds an operator parser that supports a full boolean filter grammar, including <c>AND</c>, <c>OR</c>, <c>NOT</c>, quoted values, grouping, and the default whitespace operator.
+    /// </summary>
+    /// <typeparam name="T">The type the filter is applied to.</typeparam>
+    /// <typeparam name="TTermOption">The type of the term options.</typeparam>
     public abstract class BooleanEngineBuilder<T, TTermOption> : OperatorEngineBuilder<T, TTermOption> where TTermOption : TermOption
     {
         private static readonly Parser<OperatorNode> _parser;
+        /// <summary>
+        /// The term options produced alongside the parser.
+        /// </summary>
         protected TTermOption _termOption;
 
         static BooleanEngineBuilder()
@@ -115,6 +123,10 @@ namespace YesSql.Filters.Builders
             _parser = OperatorNode;
         }
 
+        /// <summary>
+        /// Builds the boolean operator parser and its associated term options.
+        /// </summary>
+        /// <returns>A tuple containing the operator parser and the term options.</returns>
         public override (Parser<OperatorNode> Parser, TTermOption TermOption) Build()
             => (_parser, _termOption);
     }

--- a/src/YesSql.Filters.Abstractions/Builders/DefaultTermEngineBuilder.cs
+++ b/src/YesSql.Filters.Abstractions/Builders/DefaultTermEngineBuilder.cs
@@ -5,12 +5,25 @@ using static Parlot.Fluent.Parsers;
 
 namespace YesSql.Filters.Builders
 {
+    /// <summary>
+    /// Builds a term parser that accepts the term either explicitly named using the <c>name:value</c> syntax or unnamed, in which case it is treated as the default term.
+    /// </summary>
+    /// <typeparam name="T">The type the filter is applied to.</typeparam>
+    /// <typeparam name="TTermOption">The type of the term options.</typeparam>
     public class DefaultTermEngineBuilder<T, TTermOption> : TermEngineBuilder<T, TTermOption> where T : class where TTermOption : TermOption
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultTermEngineBuilder{T, TTermOption}"/> class.
+        /// </summary>
+        /// <param name="name">The name of the term.</param>
         public DefaultTermEngineBuilder(string name) : base(name)
         {
         }
 
+        /// <summary>
+        /// Builds a parser that produces a <see cref="NamedTermNode"/> when the term is named, or a <see cref="DefaultTermNode"/> when it is not.
+        /// </summary>
+        /// <returns>A tuple containing the term parser and the term options.</returns>
         public override (Parser<TermNode> Parser, TTermOption TermOption) Build()
         {
             var op = _operatorParser.Build();

--- a/src/YesSql.Filters.Abstractions/Builders/NamedTermEngineBuilder.cs
+++ b/src/YesSql.Filters.Abstractions/Builders/NamedTermEngineBuilder.cs
@@ -5,12 +5,25 @@ using static Parlot.Fluent.Parsers;
 
 namespace YesSql.Filters.Builders
 {
+    /// <summary>
+    /// Builds a term parser that requires the term to be explicitly named using the <c>name:value</c> syntax.
+    /// </summary>
+    /// <typeparam name="T">The type the filter is applied to.</typeparam>
+    /// <typeparam name="TTermOption">The type of the term options.</typeparam>
     public class NamedTermEngineBuilder<T, TTermOption> : TermEngineBuilder<T, TTermOption> where TTermOption : TermOption
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NamedTermEngineBuilder{T, TTermOption}"/> class.
+        /// </summary>
+        /// <param name="name">The name of the term.</param>
         public NamedTermEngineBuilder(string name) : base(name)
         {
         }
 
+        /// <summary>
+        /// Builds a parser that matches the term name followed by a colon and the term's operation, producing a <see cref="NamedTermNode"/>.
+        /// </summary>
+        /// <returns>A tuple containing the term parser and the term options.</returns>
         public override (Parser<TermNode> Parser, TTermOption TermOption) Build()
         {
             var op = _operatorParser.Build();

--- a/src/YesSql.Filters.Abstractions/Builders/OperatorBuilder.cs
+++ b/src/YesSql.Filters.Abstractions/Builders/OperatorBuilder.cs
@@ -4,8 +4,17 @@ using Parlot.Fluent;
 
 namespace YesSql.Filters.Builders
 {
+    /// <summary>
+    /// Represents the base class for builders that produce a parser for the operations applied within a term, together with its term options.
+    /// </summary>
+    /// <typeparam name="T">The type the filter is applied to.</typeparam>
+    /// <typeparam name="TTermOption">The type of the term options.</typeparam>
     public abstract class OperatorEngineBuilder<T, TTermOption> where TTermOption : TermOption
     {
+        /// <summary>
+        /// Builds the operator parser and its associated term options.
+        /// </summary>
+        /// <returns>A tuple containing the operator parser and the term options.</returns>
         public abstract (Parser<OperatorNode> Parser, TTermOption TermOption) Build();
     }
 }

--- a/src/YesSql.Filters.Abstractions/Builders/TermEngineBuilder.cs
+++ b/src/YesSql.Filters.Abstractions/Builders/TermEngineBuilder.cs
@@ -4,18 +4,41 @@ using Parlot.Fluent;
 
 namespace YesSql.Filters.Builders
 {
+    /// <summary>
+    /// Represents the base class for builders that produce a parser for a named term in a filter, delegating the term's operations to an <see cref="OperatorEngineBuilder{T, TTermOption}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type the filter is applied to.</typeparam>
+    /// <typeparam name="TTermOption">The type of the term options.</typeparam>
     public abstract class TermEngineBuilder<T, TTermOption>  where TTermOption : TermOption
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TermEngineBuilder{T, TTermOption}"/> class.
+        /// </summary>
+        /// <param name="name">The name of the term.</param>
         protected TermEngineBuilder(string name)
         {
             Name = name;
         }
 
+        /// <summary>
+        /// Gets the name of the term.
+        /// </summary>
         public string Name { get; }
+        /// <summary>
+        /// Gets a value indicating whether only a single occurrence of the term is allowed.
+        /// </summary>
         public bool Single { get; }
 
+        /// <summary>
+        /// The builder that produces the parser for the term's operations.
+        /// </summary>
         protected OperatorEngineBuilder<T, TTermOption> _operatorParser;
 
+        /// <summary>
+        /// Sets the operator builder used to parse the term's operations.
+        /// </summary>
+        /// <param name="operatorParser">The operator builder to use.</param>
+        /// <returns>The current <see cref="TermEngineBuilder{T, TTermOption}"/> instance, to enable chaining.</returns>
         public TermEngineBuilder<T, TTermOption> SetOperator(OperatorEngineBuilder<T, TTermOption> operatorParser)
         {
             _operatorParser = operatorParser;
@@ -23,6 +46,10 @@ namespace YesSql.Filters.Builders
             return this;
         }
 
+        /// <summary>
+        /// Builds the term parser and its associated term options.
+        /// </summary>
+        /// <returns>A tuple containing the term parser and the term options.</returns>
         public abstract (Parser<TermNode> Parser, TTermOption TermOption) Build();
     }
 }

--- a/src/YesSql.Filters.Abstractions/Builders/UnaryEngineBuilder.cs
+++ b/src/YesSql.Filters.Abstractions/Builders/UnaryEngineBuilder.cs
@@ -5,6 +5,11 @@ using static Parlot.Fluent.Parsers;
 
 namespace YesSql.Filters.Builders
 {
+    /// <summary>
+    /// Builds an operator parser that matches a single operand value, optionally quoted, without boolean composition.
+    /// </summary>
+    /// <typeparam name="T">The type the filter is applied to.</typeparam>
+    /// <typeparam name="TTermOption">The type of the term options.</typeparam>
     public abstract class UnaryEngineBuilder<T, TTermOption> : OperatorEngineBuilder<T, TTermOption> where TTermOption : TermOption
     {
         private static readonly Parser<OperatorNode> _parser = OneOf(
@@ -13,13 +18,24 @@ namespace YesSql.Filters.Builders
                 Terms.NonWhiteSpace().Then<OperatorNode>(static (node) => new UnaryNode(node.ToString(), OperateNodeQuotes.None))
             );
 
+        /// <summary>
+        /// The term options produced alongside the parser.
+        /// </summary>
         protected TTermOption _termOption;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnaryEngineBuilder{T, TTermOption}"/> class.
+        /// </summary>
+        /// <param name="termOption">The term options to associate with the parser.</param>
         protected UnaryEngineBuilder(TTermOption termOption)
         {
             _termOption = termOption;
         }
 
+        /// <summary>
+        /// Configures the term to allow multiple occurrences instead of a single one.
+        /// </summary>
+        /// <returns>The current <see cref="UnaryEngineBuilder{T, TTermOption}"/> instance, to enable chaining.</returns>
         public UnaryEngineBuilder<T, TTermOption> AllowMultiple()
         {
             _termOption.Single = false;
@@ -27,6 +43,10 @@ namespace YesSql.Filters.Builders
             return this;
         }
 
+        /// <summary>
+        /// Configures the term to always run, even when it is not specified in the filter.
+        /// </summary>
+        /// <returns>The current <see cref="UnaryEngineBuilder{T, TTermOption}"/> instance, to enable chaining.</returns>
         public UnaryEngineBuilder<T, TTermOption> AlwaysRun()
         {
             _termOption.AlwaysRun = true;
@@ -34,6 +54,10 @@ namespace YesSql.Filters.Builders
             return this;
         }
 
+        /// <summary>
+        /// Builds the unary operator parser and its associated term options.
+        /// </summary>
+        /// <returns>A tuple containing the operator parser and the term options.</returns>
         public override (Parser<OperatorNode> Parser, TTermOption TermOption) Build()
             => (_parser, _termOption);
     }

--- a/src/YesSql.Filters.Abstractions/Nodes/AndNode.cs
+++ b/src/YesSql.Filters.Abstractions/Nodes/AndNode.cs
@@ -2,8 +2,17 @@ using YesSql.Filters.Services;
 
 namespace YesSql.Filters.Nodes;
 
+/// <summary>
+/// Represents a boolean <c>AND</c> operation between two operands in a filter expression.
+/// </summary>
 public class AndNode : OperatorNode
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AndNode"/> class.
+    /// </summary>
+    /// <param name="left">The left operand of the operation.</param>
+    /// <param name="right">The right operand of the operation.</param>
+    /// <param name="value">The operator text as it appeared in the source, for example <c>AND</c> or <c>&amp;&amp;</c>.</param>
     public AndNode(OperatorNode left, OperatorNode right, string value)
     {
         Left = left;
@@ -11,14 +20,39 @@ public class AndNode : OperatorNode
         Value = value;
     }
 
+    /// <summary>
+    /// Gets the left operand of the operation.
+    /// </summary>
     public OperatorNode Left { get; }
+    /// <summary>
+    /// Gets the right operand of the operation.
+    /// </summary>
     public OperatorNode Right { get; }
+    /// <summary>
+    /// Gets the operator text as it appeared in the source.
+    /// </summary>
     public string Value { get; }
 
+    /// <summary>
+    /// Accepts a visitor and dispatches to the appropriate visit method for this node type.
+    /// </summary>
+    /// <typeparam name="TArgument">The type of the argument passed to the visitor.</typeparam>
+    /// <typeparam name="TResult">The type of the result produced by the visitor.</typeparam>
+    /// <param name="visitor">The visitor to accept.</param>
+    /// <param name="argument">The argument passed to the visitor.</param>
+    /// <returns>The result produced by the visitor.</returns>
     public override TResult Accept<TArgument, TResult>(IFilterVisitor<TArgument, TResult> visitor, TArgument argument)
         => visitor.Visit(this, argument);
+    /// <summary>
+    /// Returns a normalized string representation of the operation using the canonical <c>AND</c> operator and explicit parenthesis.
+    /// </summary>
+    /// <returns>The normalized string representation of the operation.</returns>
     public override string ToNormalizedString()
         => $"({Left.ToNormalizedString()} AND {Right.ToNormalizedString()})";
 
+    /// <summary>
+    /// Returns the string representation of the operation using the original operator text.
+    /// </summary>
+    /// <returns>The string representation of the operation.</returns>
     public override string ToString() => $"{Left} {Value} {Right}";
 }

--- a/src/YesSql.Filters.Abstractions/Nodes/AndTermNode.cs
+++ b/src/YesSql.Filters.Abstractions/Nodes/AndTermNode.cs
@@ -3,20 +3,44 @@ using YesSql.Filters.Services;
 
 namespace YesSql.Filters.Nodes;
 
+/// <summary>
+/// Represents two or more operations on the same term combined together, for example when a term is specified multiple times.
+/// </summary>
 public class AndTermNode : CompoundTermNode
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AndTermNode"/> class from an existing term operation and a newly parsed one.
+    /// </summary>
+    /// <param name="existingTerm">The previously parsed operation for the term.</param>
+    /// <param name="newTerm">The newly parsed operation for the term.</param>
     public AndTermNode(TermOperationNode existingTerm, TermOperationNode newTerm) : base(existingTerm.TermName)
     {
         Children.Add(existingTerm);
         Children.Add(newTerm);
     }
 
+    /// <summary>
+    /// Accepts a visitor and dispatches to the appropriate visit method for this node type.
+    /// </summary>
+    /// <typeparam name="TArgument">The type of the argument passed to the visitor.</typeparam>
+    /// <typeparam name="TResult">The type of the result produced by the visitor.</typeparam>
+    /// <param name="visitor">The visitor to accept.</param>
+    /// <param name="argument">The argument passed to the visitor.</param>
+    /// <returns>The result produced by the visitor.</returns>
     public override TResult Accept<TArgument, TResult>(IFilterVisitor<TArgument, TResult> visitor, TArgument argument)
         => visitor.Visit(this, argument);
 
+    /// <summary>
+    /// Returns a normalized string representation that joins the normalized form of each child operation with a space.
+    /// </summary>
+    /// <returns>The normalized string representation of the compound term.</returns>
     public override string ToNormalizedString()
         => string.Join(" ", Children.Select(c => c.ToNormalizedString()));
 
+    /// <summary>
+    /// Returns a string representation that joins each child operation with a space.
+    /// </summary>
+    /// <returns>The string representation of the compound term.</returns>
     public override string ToString()
         => string.Join(" ", Children.Select(c => c.ToString()));
 }

--- a/src/YesSql.Filters.Abstractions/Nodes/CompoundTermNode.cs
+++ b/src/YesSql.Filters.Abstractions/Nodes/CompoundTermNode.cs
@@ -2,11 +2,21 @@ using System.Collections.Generic;
 
 namespace YesSql.Filters.Nodes;
 
+/// <summary>
+/// Represents a term that aggregates multiple operations sharing the same term name into a single compound node.
+/// </summary>
 public abstract class CompoundTermNode : TermNode
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CompoundTermNode"/> class.
+    /// </summary>
+    /// <param name="termName">The name of the term.</param>
     protected CompoundTermNode(string termName) : base(termName)
     {
     }
 
+    /// <summary>
+    /// Gets the operations that compose this term.
+    /// </summary>
     public List<TermOperationNode> Children { get; } = new List<TermOperationNode>();
 }

--- a/src/YesSql.Filters.Abstractions/Nodes/DefaultTermNode.cs
+++ b/src/YesSql.Filters.Abstractions/Nodes/DefaultTermNode.cs
@@ -1,13 +1,29 @@
 namespace YesSql.Filters.Nodes;
 
+/// <summary>
+/// Represents a term that was not explicitly named in the filter expression and is associated with a default term name.
+/// </summary>
 public class DefaultTermNode : TermOperationNode
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultTermNode"/> class.
+    /// </summary>
+    /// <param name="termName">The default name assigned to the term.</param>
+    /// <param name="operation">The operation applied to the term.</param>
     public DefaultTermNode(string termName, OperatorNode operation) : base(termName, operation)
     {
     }
 
+    /// <summary>
+    /// Returns a normalized string representation of the term, including the default term name even though it was not specified.
+    /// </summary>
+    /// <returns>The normalized string in the form <c>name:value</c>.</returns>
     public override string ToNormalizedString() // normalizing includes the term name even if not specified.
         => $"{TermName}:{Operation.ToNormalizedString()}";
 
+    /// <summary>
+    /// Returns the string representation of the term, containing only the operation value as it was originally written.
+    /// </summary>
+    /// <returns>The string representation of the operation.</returns>
     public override string ToString() => $"{Operation}";
 }

--- a/src/YesSql.Filters.Abstractions/Nodes/FilterNode.cs
+++ b/src/YesSql.Filters.Abstractions/Nodes/FilterNode.cs
@@ -2,10 +2,25 @@ using YesSql.Filters.Services;
 
 namespace YesSql.Filters.Nodes
 {
+    /// <summary>
+    /// Represents the base class for all nodes in a parsed filter expression tree.
+    /// </summary>
     public abstract class FilterNode
     {
+        /// <summary>
+        /// Returns a normalized string representation of the node, applying canonical boolean logic and formatting.
+        /// </summary>
+        /// <returns>The normalized string representation of the node.</returns>
         public abstract string ToNormalizedString();
 
+        /// <summary>
+        /// Accepts a visitor and dispatches to the appropriate visit method for this node type.
+        /// </summary>
+        /// <typeparam name="TArgument">The type of the argument passed to the visitor.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the visitor.</typeparam>
+        /// <param name="visitor">The visitor to accept.</param>
+        /// <param name="argument">The argument passed to the visitor.</param>
+        /// <returns>The result produced by the visitor.</returns>
         public abstract TResult Accept<TArgument, TResult>(IFilterVisitor<TArgument, TResult> visitor, TArgument argument);
     }
 }

--- a/src/YesSql.Filters.Abstractions/Nodes/GroupNode.cs
+++ b/src/YesSql.Filters.Abstractions/Nodes/GroupNode.cs
@@ -7,18 +7,41 @@ namespace YesSql.Filters.Nodes;
 /// </summary>
 public class GroupNode : OperatorNode
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GroupNode"/> class.
+    /// </summary>
+    /// <param name="operation">The operation enclosed by the group.</param>
     public GroupNode(OperatorNode operation)
     {
         Operation = operation;
     }
 
+    /// <summary>
+    /// Gets the operation enclosed by the group.
+    /// </summary>
     public OperatorNode Operation { get; }
 
+    /// <summary>
+    /// Accepts a visitor and dispatches to the appropriate visit method for this node type.
+    /// </summary>
+    /// <typeparam name="TArgument">The type of the argument passed to the visitor.</typeparam>
+    /// <typeparam name="TResult">The type of the result produced by the visitor.</typeparam>
+    /// <param name="visitor">The visitor to accept.</param>
+    /// <param name="argument">The argument passed to the visitor.</param>
+    /// <returns>The result produced by the visitor.</returns>
     public override TResult Accept<TArgument, TResult>(IFilterVisitor<TArgument, TResult> visitor, TArgument argument)
         => visitor.Visit(this, argument);
 
+    /// <summary>
+    /// Returns a normalized string representation of the group, preserving the surrounding parenthesis.
+    /// </summary>
+    /// <returns>The normalized string representation of the group.</returns>
     public override string ToNormalizedString()
         => ToString();
 
+    /// <summary>
+    /// Returns the string representation of the group, including the surrounding parenthesis.
+    /// </summary>
+    /// <returns>The string representation of the group.</returns>
     public override string ToString() => $"({Operation})";
 }

--- a/src/YesSql.Filters.Abstractions/Nodes/NamedTermNode.cs
+++ b/src/YesSql.Filters.Abstractions/Nodes/NamedTermNode.cs
@@ -1,12 +1,28 @@
 namespace YesSql.Filters.Nodes;
 
+/// <summary>
+/// Represents a term that is explicitly named in the filter expression using the <c>name:value</c> syntax.
+/// </summary>
 public class NamedTermNode : TermOperationNode
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NamedTermNode"/> class.
+    /// </summary>
+    /// <param name="termName">The name of the term.</param>
+    /// <param name="operation">The operation applied to the term.</param>
     public NamedTermNode(string termName, OperatorNode operation) : base(termName, operation)
     {
     }
 
+    /// <summary>
+    /// Returns a normalized string representation of the term, including its name.
+    /// </summary>
+    /// <returns>The normalized string in the form <c>name:value</c>.</returns>
     public override string ToNormalizedString() => $"{TermName}:{Operation.ToNormalizedString()}";
 
+    /// <summary>
+    /// Returns the string representation of the term, including its name.
+    /// </summary>
+    /// <returns>The string in the form <c>name:value</c>.</returns>
     public override string ToString() => $"{TermName}:{Operation}";
 }

--- a/src/YesSql.Filters.Abstractions/Nodes/NotNode.cs
+++ b/src/YesSql.Filters.Abstractions/Nodes/NotNode.cs
@@ -1,13 +1,30 @@
 namespace YesSql.Filters.Nodes;
 
+/// <summary>
+/// Represents a boolean <c>NOT</c> operation that excludes the right operand from the result of the left operand.
+/// </summary>
 public class NotNode : AndNode
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NotNode"/> class.
+    /// </summary>
+    /// <param name="left">The left operand of the operation.</param>
+    /// <param name="right">The right operand that is negated.</param>
+    /// <param name="value">The operator text as it appeared in the source, for example <c>NOT</c> or <c>!</c>.</param>
     public NotNode(OperatorNode left, OperatorNode right, string value) : base(left, right, value)
     {
     }
 
+    /// <summary>
+    /// Returns a normalized string representation of the operation using the canonical <c>NOT</c> operator and explicit parenthesis.
+    /// </summary>
+    /// <returns>The normalized string representation of the operation.</returns>
     public override string ToNormalizedString()
         => $"({Left.ToNormalizedString()} NOT {Right.ToNormalizedString()})";
 
+    /// <summary>
+    /// Returns the string representation of the operation using the original operator text.
+    /// </summary>
+    /// <returns>The string representation of the operation.</returns>
     public override string ToString() => $"{Left} {Value} {Right}";
 }

--- a/src/YesSql.Filters.Abstractions/Nodes/NotUnaryNode.cs
+++ b/src/YesSql.Filters.Abstractions/Nodes/NotUnaryNode.cs
@@ -2,21 +2,51 @@ using YesSql.Filters.Services;
 
 namespace YesSql.Filters.Nodes;
 
+/// <summary>
+/// Represents a unary operation that negates a single operand, for example a leading <c>NOT</c> or <c>!</c> applied to a value.
+/// </summary>
 public class NotUnaryNode : OperatorNode
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NotUnaryNode"/> class.
+    /// </summary>
+    /// <param name="operatorValue">The operator text as it appeared in the source, for example <c>NOT</c> or <c>!</c>.</param>
+    /// <param name="operation">The operand that is negated.</param>
     public NotUnaryNode(string operatorValue, UnaryNode operation)
     {
         OperatorValue = operatorValue;
         Operation = operation;
     }
 
+    /// <summary>
+    /// Gets the operator text as it appeared in the source.
+    /// </summary>
     public string OperatorValue { get; }
+    /// <summary>
+    /// Gets the operand that is negated.
+    /// </summary>
     public UnaryNode Operation { get; }
 
+    /// <summary>
+    /// Accepts a visitor and dispatches to the appropriate visit method for this node type.
+    /// </summary>
+    /// <typeparam name="TArgument">The type of the argument passed to the visitor.</typeparam>
+    /// <typeparam name="TResult">The type of the result produced by the visitor.</typeparam>
+    /// <param name="visitor">The visitor to accept.</param>
+    /// <param name="argument">The argument passed to the visitor.</param>
+    /// <returns>The result produced by the visitor.</returns>
     public override TResult Accept<TArgument, TResult>(IFilterVisitor<TArgument, TResult> visitor, TArgument argument)
         => visitor.Visit(this, argument);
+    /// <summary>
+    /// Returns a normalized string representation combining the operator and the negated operand.
+    /// </summary>
+    /// <returns>The normalized string representation of the operation.</returns>
     public override string ToNormalizedString()
         => ToString();
 
+    /// <summary>
+    /// Returns the string representation combining the operator and the negated operand.
+    /// </summary>
+    /// <returns>The string representation of the operation.</returns>
     public override string ToString() => $"{OperatorValue} {Operation}";
 }

--- a/src/YesSql.Filters.Abstractions/Nodes/OperateNodeQuotes.cs
+++ b/src/YesSql.Filters.Abstractions/Nodes/OperateNodeQuotes.cs
@@ -1,8 +1,20 @@
 namespace YesSql.Filters.Nodes;
 
+/// <summary>
+/// Specifies the kind of quoting that surrounded the value of a <see cref="UnaryNode"/> in the source filter expression.
+/// </summary>
 public enum OperateNodeQuotes
 {
+    /// <summary>
+    /// The value was not enclosed in quotes.
+    /// </summary>
     None,
+    /// <summary>
+    /// The value was enclosed in double quotes.
+    /// </summary>
     Double,
+    /// <summary>
+    /// The value was enclosed in single quotes.
+    /// </summary>
     Single
 }

--- a/src/YesSql.Filters.Abstractions/Nodes/OperatorNode.cs
+++ b/src/YesSql.Filters.Abstractions/Nodes/OperatorNode.cs
@@ -1,5 +1,8 @@
 namespace YesSql.Filters.Nodes
 {
+    /// <summary>
+    /// Represents the base class for nodes that produce an operation within a filter expression, such as boolean operators and operands.
+    /// </summary>
     public abstract class OperatorNode : FilterNode
     {
     }

--- a/src/YesSql.Filters.Abstractions/Nodes/OrNode.cs
+++ b/src/YesSql.Filters.Abstractions/Nodes/OrNode.cs
@@ -2,8 +2,17 @@ using YesSql.Filters.Services;
 
 namespace YesSql.Filters.Nodes;
 
+/// <summary>
+/// Represents a boolean <c>OR</c> operation between two operands in a filter expression. This is also the default operation when operands are separated only by whitespace.
+/// </summary>
 public class OrNode : OperatorNode
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OrNode"/> class.
+    /// </summary>
+    /// <param name="left">The left operand of the operation.</param>
+    /// <param name="right">The right operand of the operation.</param>
+    /// <param name="value">The operator text as it appeared in the source, for example <c>OR</c> or <c>||</c>, or an empty value when the default whitespace operator was used.</param>
     public OrNode(OperatorNode left, OperatorNode right, string value)
     {
         Left = left;
@@ -11,16 +20,41 @@ public class OrNode : OperatorNode
         Value = value;
     }
 
+    /// <summary>
+    /// Gets the left operand of the operation.
+    /// </summary>
     public OperatorNode Left { get; }
+    /// <summary>
+    /// Gets the right operand of the operation.
+    /// </summary>
     public OperatorNode Right { get; }
+    /// <summary>
+    /// Gets the operator text as it appeared in the source.
+    /// </summary>
     public string Value { get; }
 
+    /// <summary>
+    /// Accepts a visitor and dispatches to the appropriate visit method for this node type.
+    /// </summary>
+    /// <typeparam name="TArgument">The type of the argument passed to the visitor.</typeparam>
+    /// <typeparam name="TResult">The type of the result produced by the visitor.</typeparam>
+    /// <param name="visitor">The visitor to accept.</param>
+    /// <param name="argument">The argument passed to the visitor.</param>
+    /// <returns>The result produced by the visitor.</returns>
     public override TResult Accept<TArgument, TResult>(IFilterVisitor<TArgument, TResult> visitor, TArgument argument)
         => visitor.Visit(this, argument);
 
+    /// <summary>
+    /// Returns a normalized string representation of the operation using the canonical <c>OR</c> operator and explicit parenthesis.
+    /// </summary>
+    /// <returns>The normalized string representation of the operation.</returns>
     public override string ToNormalizedString()
         => $"({Left.ToNormalizedString()} OR {Right.ToNormalizedString()})";
 
+    /// <summary>
+    /// Returns the string representation of the operation, omitting the operator text when the default whitespace operator was used.
+    /// </summary>
+    /// <returns>The string representation of the operation.</returns>
     public override string ToString()
         => string.IsNullOrWhiteSpace(Value) ? $"{Left} {Right}" : $"{Left} {Value} {Right}";
 }

--- a/src/YesSql.Filters.Abstractions/Nodes/TermNode.cs
+++ b/src/YesSql.Filters.Abstractions/Nodes/TermNode.cs
@@ -2,14 +2,32 @@ using YesSql.Filters.Services;
 
 namespace YesSql.Filters.Nodes
 {
+    /// <summary>
+    /// Represents the base class for a named term in a filter expression, identifying the field or facet the filter applies to.
+    /// </summary>
     public abstract class TermNode : FilterNode
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TermNode"/> class.
+        /// </summary>
+        /// <param name="termName">The name of the term.</param>
         protected TermNode(string termName)
         {
             TermName = termName;
         }
 
+        /// <summary>
+        /// Gets the name of the term.
+        /// </summary>
         public string TermName { get; }
+        /// <summary>
+        /// Accepts a visitor and dispatches to the appropriate visit method for this node type.
+        /// </summary>
+        /// <typeparam name="TArgument">The type of the argument passed to the visitor.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the visitor.</typeparam>
+        /// <param name="visitor">The visitor to accept.</param>
+        /// <param name="argument">The argument passed to the visitor.</param>
+        /// <returns>The result produced by the visitor.</returns>
         public override TResult Accept<TArgument, TResult>(IFilterVisitor<TArgument, TResult> visitor, TArgument argument)
             => visitor.Visit(this, argument);
     }

--- a/src/YesSql.Filters.Abstractions/Nodes/TermOperationNode.cs
+++ b/src/YesSql.Filters.Abstractions/Nodes/TermOperationNode.cs
@@ -2,15 +2,34 @@ using YesSql.Filters.Services;
 
 namespace YesSql.Filters.Nodes;
 
+/// <summary>
+/// Represents a term that applies an operation, such as a comparison or boolean expression, to a named term.
+/// </summary>
 public abstract class TermOperationNode : TermNode
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TermOperationNode"/> class.
+    /// </summary>
+    /// <param name="termName">The name of the term.</param>
+    /// <param name="operation">The operation applied to the term.</param>
     protected TermOperationNode(string termName, OperatorNode operation) : base(termName)
     {
         Operation = operation;
     }
 
+    /// <summary>
+    /// Gets the operation applied to the term.
+    /// </summary>
     public OperatorNode Operation { get; }
 
+    /// <summary>
+    /// Accepts a visitor and dispatches to the appropriate visit method for this node type.
+    /// </summary>
+    /// <typeparam name="TArgument">The type of the argument passed to the visitor.</typeparam>
+    /// <typeparam name="TResult">The type of the result produced by the visitor.</typeparam>
+    /// <param name="visitor">The visitor to accept.</param>
+    /// <param name="argument">The argument passed to the visitor.</param>
+    /// <returns>The result produced by the visitor.</returns>
     public override TResult Accept<TArgument, TResult>(IFilterVisitor<TArgument, TResult> visitor, TArgument argument)
         => visitor.Visit(this, argument);
 }

--- a/src/YesSql.Filters.Abstractions/Nodes/UnaryNode.cs
+++ b/src/YesSql.Filters.Abstractions/Nodes/UnaryNode.cs
@@ -3,8 +3,17 @@ using YesSql.Filters.Services;
 
 namespace YesSql.Filters.Nodes;
 
+/// <summary>
+/// Represents a single operand value in a filter expression, optionally quoted.
+/// </summary>
 public class UnaryNode : OperatorNode
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnaryNode"/> class.
+    /// </summary>
+    /// <param name="value">The operand value.</param>
+    /// <param name="quotes">The kind of quoting that surrounded the value in the source.</param>
+    /// <param name="useMatch">Whether the value should be treated as a match expression rather than a negation or exclusion.</param>
     public UnaryNode(string value, OperateNodeQuotes quotes, bool useMatch = true)
     {
         Value = value;
@@ -12,14 +21,34 @@ public class UnaryNode : OperatorNode
         UseMatch = useMatch;
     }
 
+    /// <summary>
+    /// Gets the operand value.
+    /// </summary>
     public string Value { get; }
+    /// <summary>
+    /// Gets the kind of quoting that surrounded the value in the source.
+    /// </summary>
     public OperateNodeQuotes Quotes { get; }
+    /// <summary>
+    /// Gets a value indicating whether the value should be treated as a match expression.
+    /// </summary>
     public bool UseMatch { get; }
+    /// <summary>
+    /// Gets a value indicating whether the node has a non-empty value.
+    /// </summary>
     public bool HasValue => !string.IsNullOrEmpty(Value);
 
+    /// <summary>
+    /// Returns a normalized string representation of the value, preserving any quoting.
+    /// </summary>
+    /// <returns>The normalized string representation of the value.</returns>
     public override string ToNormalizedString()
         => ToString();
 
+    /// <summary>
+    /// Returns the string representation of the value, re-applying the original quotes when present.
+    /// </summary>
+    /// <returns>The quoted value, or an empty string when the node has no value.</returns>
     public override string ToString()
     {
         if (HasValue)
@@ -38,6 +67,14 @@ public class UnaryNode : OperatorNode
         }
     }
 
+    /// <summary>
+    /// Accepts a visitor and dispatches to the appropriate visit method for this node type.
+    /// </summary>
+    /// <typeparam name="TArgument">The type of the argument passed to the visitor.</typeparam>
+    /// <typeparam name="TResult">The type of the result produced by the visitor.</typeparam>
+    /// <param name="visitor">The visitor to accept.</param>
+    /// <param name="argument">The argument passed to the visitor.</param>
+    /// <returns>The result produced by the visitor.</returns>
     public override TResult Accept<TArgument, TResult>(IFilterVisitor<TArgument, TResult> visitor, TArgument argument)
         => visitor.Visit(this, argument);
 }

--- a/src/YesSql.Filters.Abstractions/Services/FilterExecutionContext.cs
+++ b/src/YesSql.Filters.Abstractions/Services/FilterExecutionContext.cs
@@ -1,12 +1,23 @@
 namespace YesSql.Filters.Services
 {
+    /// <summary>
+    /// Represents the context in which a filter term is executed against a single item.
+    /// </summary>
+    /// <typeparam name="T">The type of the item being filtered.</typeparam>
     public abstract class FilterExecutionContext<T>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FilterExecutionContext{T}"/> class.
+        /// </summary>
+        /// <param name="item">The item the filter is executed against.</param>
         protected FilterExecutionContext(T item)
         {
             Item = item;
         }
 
+        /// <summary>
+        /// Gets or sets the item the filter is executed against.
+        /// </summary>
         public T Item { get; set; }
     }
 }

--- a/src/YesSql.Filters.Abstractions/Services/FilterResult.cs
+++ b/src/YesSql.Filters.Abstractions/Services/FilterResult.cs
@@ -6,16 +6,33 @@ using YesSql.Filters.Nodes;
 
 namespace YesSql.Filters.Services
 {
+    /// <summary>
+    /// Represents the result of parsing a filter expression as a collection of <see cref="TermNode"/> instances, providing mapping and serialization helpers.
+    /// </summary>
+    /// <typeparam name="T">The type the filter is applied to.</typeparam>
+    /// <typeparam name="TTermOption">The type of the term options.</typeparam>
     public abstract class FilterResult<T, TTermOption> : IEnumerable<TermNode> where TTermOption : TermOption
     {
 
+        /// <summary>
+        /// The parsed terms keyed by their term name, compared case-insensitively.
+        /// </summary>
         protected Dictionary<string, TermNode> _terms = new Dictionary<string, TermNode>(StringComparer.OrdinalIgnoreCase);
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FilterResult{T, TTermOption}"/> class with the specified term options.
+        /// </summary>
+        /// <param name="termOptions">The configured options keyed by term name.</param>
         protected FilterResult(IReadOnlyDictionary<string, TTermOption> termOptions)
         {
             TermOptions = termOptions;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FilterResult{T, TTermOption}"/> class from a set of parsed terms.
+        /// </summary>
+        /// <param name="terms">The parsed terms to add to the result.</param>
+        /// <param name="termOptions">The configured options keyed by term name.</param>
         protected FilterResult(IReadOnlyList<TermNode> terms, IReadOnlyDictionary<string, TTermOption> termOptions)
         {
             TermOptions = termOptions;
@@ -105,6 +122,10 @@ namespace YesSql.Filters.Services
         public bool TryRemove(string name)
             => _terms.Remove(name);        
 
+        /// <summary>
+        /// Returns an enumerator that iterates through the parsed terms.
+        /// </summary>
+        /// <returns>An enumerator for the parsed terms.</returns>
         public IEnumerator<TermNode> GetEnumerator()
             => _terms.Values.GetEnumerator();
 

--- a/src/YesSql.Filters.Abstractions/Services/IFilterParser.cs
+++ b/src/YesSql.Filters.Abstractions/Services/IFilterParser.cs
@@ -1,7 +1,16 @@
 namespace YesSql.Filters.Services
 {
+    /// <summary>
+    /// Defines a parser that converts a filter expression string into a strongly typed result.
+    /// </summary>
+    /// <typeparam name="TResult">The type produced by the parser.</typeparam>
     public interface IFilterParser<TResult>
     {
+        /// <summary>
+        /// Parses the specified filter expression.
+        /// </summary>
+        /// <param name="text">The filter expression to parse.</param>
+        /// <returns>The parsed result.</returns>
         TResult Parse(string text);
     }
 }

--- a/src/YesSql.Filters.Abstractions/Services/IFilterVisitor.cs
+++ b/src/YesSql.Filters.Abstractions/Services/IFilterVisitor.cs
@@ -2,15 +2,68 @@ using YesSql.Filters.Nodes;
 
 namespace YesSql.Filters.Services
 {
+    /// <summary>
+    /// Defines a visitor that traverses the nodes of a parsed filter expression tree and produces a result for each node type.
+    /// </summary>
+    /// <typeparam name="TArgument">The type of the argument passed through the traversal.</typeparam>
+    /// <typeparam name="TResult">The type of the result produced for each node.</typeparam>
     public interface IFilterVisitor<TArgument, TResult>
     {
+        /// <summary>
+        /// Visits a <see cref="TermNode"/>.
+        /// </summary>
+        /// <param name="node">The node to visit.</param>
+        /// <param name="argument">The argument passed through the traversal.</param>
+        /// <returns>The result produced for the node.</returns>
         TResult Visit(TermNode node, TArgument argument);
+        /// <summary>
+        /// Visits a <see cref="TermOperationNode"/>.
+        /// </summary>
+        /// <param name="node">The node to visit.</param>
+        /// <param name="argument">The argument passed through the traversal.</param>
+        /// <returns>The result produced for the node.</returns>
         TResult Visit(TermOperationNode node, TArgument argument);
+        /// <summary>
+        /// Visits an <see cref="AndTermNode"/>.
+        /// </summary>
+        /// <param name="node">The node to visit.</param>
+        /// <param name="argument">The argument passed through the traversal.</param>
+        /// <returns>The result produced for the node.</returns>
         TResult Visit(AndTermNode node, TArgument argument);
+        /// <summary>
+        /// Visits a <see cref="UnaryNode"/>.
+        /// </summary>
+        /// <param name="node">The node to visit.</param>
+        /// <param name="argument">The argument passed through the traversal.</param>
+        /// <returns>The result produced for the node.</returns>
         TResult Visit(UnaryNode node, TArgument argument);
+        /// <summary>
+        /// Visits a <see cref="NotUnaryNode"/>.
+        /// </summary>
+        /// <param name="node">The node to visit.</param>
+        /// <param name="argument">The argument passed through the traversal.</param>
+        /// <returns>The result produced for the node.</returns>
         TResult Visit(NotUnaryNode node, TArgument argument);
+        /// <summary>
+        /// Visits an <see cref="OrNode"/>.
+        /// </summary>
+        /// <param name="node">The node to visit.</param>
+        /// <param name="argument">The argument passed through the traversal.</param>
+        /// <returns>The result produced for the node.</returns>
         TResult Visit(OrNode node, TArgument argument);
+        /// <summary>
+        /// Visits an <see cref="AndNode"/>.
+        /// </summary>
+        /// <param name="node">The node to visit.</param>
+        /// <param name="argument">The argument passed through the traversal.</param>
+        /// <returns>The result produced for the node.</returns>
         TResult Visit(AndNode node, TArgument argument);
+        /// <summary>
+        /// Visits a <see cref="GroupNode"/>.
+        /// </summary>
+        /// <param name="node">The node to visit.</param>
+        /// <param name="argument">The argument passed through the traversal.</param>
+        /// <returns>The result produced for the node.</returns>
         TResult Visit(GroupNode node, TArgument argument);
     }
 }

--- a/src/YesSql.Filters.Abstractions/Services/TermOption.cs
+++ b/src/YesSql.Filters.Abstractions/Services/TermOption.cs
@@ -3,13 +3,23 @@ using YesSql.Filters.Nodes;
 
 namespace YesSql.Filters.Services
 {
+    /// <summary>
+    /// Represents the configuration options associated with a term in a filter, including how it maps to and from a model.
+    /// </summary>
     public abstract class TermOption
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TermOption"/> class.
+        /// </summary>
+        /// <param name="name">The name of the term these options apply to.</param>
         protected TermOption(string name)
         {
             Name = name;
         }
 
+        /// <summary>
+        /// Gets the name of the term these options apply to.
+        /// </summary>
         public string Name { get; }
 
         /// <summary>
@@ -22,8 +32,17 @@ namespace YesSql.Filters.Services
         /// </summary>
         public bool AlwaysRun { get; set; }
 
+        /// <summary>
+        /// Gets or sets the delegate that maps the term value to a model.
+        /// </summary>
         public Delegate MapTo { get; set; }
+        /// <summary>
+        /// Gets or sets the delegate that maps a value from a model back to the term.
+        /// </summary>
         public Delegate MapFrom { get; set; }
+        /// <summary>
+        /// Gets or sets the factory that builds a <see cref="TermNode"/> from a term name and value when mapping from a model.
+        /// </summary>
         public Func<string, string, TermNode> MapFromFactory { get; set; }
     }
 }

--- a/src/YesSql.Filters.Query/QueryBooleanEngineBuilder.cs
+++ b/src/YesSql.Filters.Query/QueryBooleanEngineBuilder.cs
@@ -5,8 +5,18 @@ using YesSql.Filters.Query.Services;
 
 namespace YesSql.Filters.Query
 {
+    /// <summary>
+    /// Builds a term that supports many operations (AND, OR and NOT) for an <see cref="IQuery{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the queried document.</typeparam>
     public class QueryBooleanEngineBuilder<T> : BooleanEngineBuilder<T, QueryTermOption<T>> where T : class
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QueryBooleanEngineBuilder{T}"/> class.
+        /// </summary>
+        /// <param name="name">The name of the term.</param>
+        /// <param name="matchQuery">The predicate to apply when the term is parsed with an AND or OR operator.</param>
+        /// <param name="notMatchQuery">The predicate to apply when the term is parsed with a NOT operator.</param>
         public QueryBooleanEngineBuilder(
             string name,
             Func<string, IQuery<T>, QueryExecutionContext<T>, ValueTask<IQuery<T>>> matchQuery,

--- a/src/YesSql.Filters.Query/QueryEngineBuilder.cs
+++ b/src/YesSql.Filters.Query/QueryEngineBuilder.cs
@@ -13,6 +13,11 @@ namespace YesSql.Filters.Query
     {
         private readonly Dictionary<string, TermEngineBuilder<T, QueryTermOption<T>>> _termBuilders = [];
 
+        /// <summary>
+        /// Registers a term parser on the builder.
+        /// </summary>
+        /// <param name="builder">The term parser builder to register.</param>
+        /// <returns>The <see cref="QueryEngineBuilder{T}"/> instance to allow chaining.</returns>
         public QueryEngineBuilder<T> SetTermParser(TermEngineBuilder<T, QueryTermOption<T>> builder)
         {
             _termBuilders[builder.Name] = builder;
@@ -20,6 +25,10 @@ namespace YesSql.Filters.Query
             return this;
         }
 
+        /// <summary>
+        /// Builds the <see cref="IQueryParser{T}"/> from the registered terms.
+        /// </summary>
+        /// <returns>A new <see cref="IQueryParser{T}"/> instance.</returns>
         public IQueryParser<T> Build()
         {
             var builders = _termBuilders.Values.Select(x => x.Build());

--- a/src/YesSql.Filters.Query/QueryEngineBuilderExtensions.cs
+++ b/src/YesSql.Filters.Query/QueryEngineBuilderExtensions.cs
@@ -4,6 +4,9 @@ using YesSql.Filters.Query.Services;
 
 namespace YesSql.Filters.Query
 {
+    /// <summary>
+    /// Provides extension methods to add terms to a <see cref="QueryEngineBuilder{T}"/>.
+    /// </summary>
     public static class QueryEngineBuilderExtensions
     {
         /// <summary>

--- a/src/YesSql.Filters.Query/QueryFilterResult.cs
+++ b/src/YesSql.Filters.Query/QueryFilterResult.cs
@@ -7,14 +7,32 @@ using YesSql.Filters.Query.Services;
 
 namespace YesSql.Filters.Query
 {
+    /// <summary>
+    /// Represents the result of parsing a query filter that can be applied to an <see cref="IQuery{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the queried document.</typeparam>
     public class QueryFilterResult<T> : FilterResult<T, QueryTermOption<T>> where T : class
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QueryFilterResult{T}"/> class.
+        /// </summary>
+        /// <param name="termOptions">The available term options.</param>
         public QueryFilterResult(IReadOnlyDictionary<string, QueryTermOption<T>> termOptions) : base(termOptions)
         { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QueryFilterResult{T}"/> class.
+        /// </summary>
+        /// <param name="terms">The parsed terms.</param>
+        /// <param name="termOptions">The available term options.</param>
         public QueryFilterResult(IReadOnlyList<TermNode> terms, IReadOnlyDictionary<string, QueryTermOption<T>> termOptions) : base(terms, termOptions)
         { }
 
+        /// <summary>
+        /// Maps the terms from the specified model.
+        /// </summary>
+        /// <typeparam name="TModel">The type of the model to map from.</typeparam>
+        /// <param name="model">The model to map the terms from.</param>
         public void MapFrom<TModel>(TModel model)
         {
             foreach (var option in TermOptions)

--- a/src/YesSql.Filters.Query/QueryFilterResultExtensions.cs
+++ b/src/YesSql.Filters.Query/QueryFilterResultExtensions.cs
@@ -3,8 +3,18 @@ using YesSql.Filters.Query.Services;
 
 namespace YesSql.Filters.Query
 {
+    /// <summary>
+    /// Provides extension methods to execute a <see cref="QueryFilterResult{T}"/> against an <see cref="IQuery{T}"/>.
+    /// </summary>
     public static class QueryFilterResultExtensions
     {
+        /// <summary>
+        /// Applies the term filters to the specified <see cref="IQuery{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the queried document.</typeparam>
+        /// <param name="result">The filter result to execute.</param>
+        /// <param name="query">The query to apply the term filters to.</param>
+        /// <returns>The filtered <see cref="IQuery{T}"/>.</returns>
         public static ValueTask<IQuery<T>> ExecuteAsync<T>(this QueryFilterResult<T> result, IQuery<T> query) where T : class
             => result.ExecuteAsync(new QueryExecutionContext<T>(query));
     }

--- a/src/YesSql.Filters.Query/QueryTermEngineBuilderExtensions.cs
+++ b/src/YesSql.Filters.Query/QueryTermEngineBuilderExtensions.cs
@@ -5,6 +5,9 @@ using YesSql.Filters.Query.Services;
 
 namespace YesSql.Filters.Query
 {
+    /// <summary>
+    /// Provides extension methods to add conditions to a <see cref="TermEngineBuilder{T, TTermOption}"/>.
+    /// </summary>
     public static class QueryTermFilterBuilderExtensions
     {
         /// <summary>

--- a/src/YesSql.Filters.Query/QueryUnaryEngineBuilder.cs
+++ b/src/YesSql.Filters.Query/QueryUnaryEngineBuilder.cs
@@ -7,8 +7,17 @@ using YesSql.Filters.Query.Services;
 
 namespace YesSql.Filters.Query
 {
+    /// <summary>
+    /// Builds a term that supports a single condition for an <see cref="IQuery{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the queried document.</typeparam>
     public class QueryUnaryEngineBuilder<T> : UnaryEngineBuilder<T, QueryTermOption<T>> where T : class
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QueryUnaryEngineBuilder{T}"/> class.
+        /// </summary>
+        /// <param name="name">The name of the term.</param>
+        /// <param name="query">The predicate to apply when the term is parsed.</param>
         public QueryUnaryEngineBuilder(string name, Func<string, IQuery<T>, QueryExecutionContext<T>, ValueTask<IQuery<T>>> query) : base(new QueryTermOption<T>(name, query))
         {
         }

--- a/src/YesSql.Filters.Query/Services/QueryExecutionContext.cs
+++ b/src/YesSql.Filters.Query/Services/QueryExecutionContext.cs
@@ -2,12 +2,23 @@ using YesSql.Filters.Services;
 
 namespace YesSql.Filters.Query.Services
 {
+    /// <summary>
+    /// Represents the execution context used when applying query filters to an <see cref="IQuery{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the queried document.</typeparam>
     public class QueryExecutionContext<T> : FilterExecutionContext<IQuery<T>> where T : class
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QueryExecutionContext{T}"/> class.
+        /// </summary>
+        /// <param name="query">The query the filters are applied to.</param>
         public QueryExecutionContext(IQuery<T> query) : base(query)
         {
         }
 
+        /// <summary>
+        /// Gets or sets the term option currently being executed.
+        /// </summary>
         public QueryTermOption<T> CurrentTermOption { get; set; }
     }
 }

--- a/src/YesSql.Filters.Query/Services/QueryFilterVisitor.cs
+++ b/src/YesSql.Filters.Query/Services/QueryFilterVisitor.cs
@@ -6,11 +6,27 @@ using YesSql.Filters.Services;
 
 namespace YesSql.Filters.Query.Services
 {
+    /// <summary>
+    /// Visits the nodes of a parsed query filter and builds the predicates applied to an <see cref="IQuery{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the queried document.</typeparam>
     public class QueryFilterVisitor<T> : IFilterVisitor<QueryExecutionContext<T>, Func<IQuery<T>, ValueTask<IQuery<T>>>> where T : class
     {
+        /// <summary>
+        /// Visits a <see cref="TermOperationNode"/> and returns the predicate to apply.
+        /// </summary>
+        /// <param name="node">The node to visit.</param>
+        /// <param name="argument">The current execution context.</param>
+        /// <returns>The predicate to apply to the query.</returns>
         public Func<IQuery<T>, ValueTask<IQuery<T>>> Visit(TermOperationNode node, QueryExecutionContext<T> argument)
             => node.Operation.Accept(this, argument);
 
+        /// <summary>
+        /// Visits an <see cref="AndTermNode"/> and returns the predicate to apply.
+        /// </summary>
+        /// <param name="node">The node to visit.</param>
+        /// <param name="argument">The current execution context.</param>
+        /// <returns>The predicate to apply to the query.</returns>
         public Func<IQuery<T>, ValueTask<IQuery<T>>> Visit(AndTermNode node, QueryExecutionContext<T> argument)
         {
             var predicates = new List<Func<IQuery<T>, ValueTask<IQuery<T>>>>();
@@ -27,6 +43,12 @@ namespace YesSql.Filters.Query.Services
             return result;
         }
 
+        /// <summary>
+        /// Visits a <see cref="UnaryNode"/> and returns the predicate to apply.
+        /// </summary>
+        /// <param name="node">The node to visit.</param>
+        /// <param name="argument">The current execution context.</param>
+        /// <returns>The predicate to apply to the query.</returns>
         public Func<IQuery<T>, ValueTask<IQuery<T>>> Visit(UnaryNode node, QueryExecutionContext<T> argument)
         {
             var currentQuery = argument.CurrentTermOption.MatchPredicate;
@@ -38,6 +60,12 @@ namespace YesSql.Filters.Query.Services
             return result => currentQuery(node.Value, argument.Item, argument);
         }
 
+        /// <summary>
+        /// Visits a <see cref="NotUnaryNode"/> and returns the predicate to apply.
+        /// </summary>
+        /// <param name="node">The node to visit.</param>
+        /// <param name="argument">The current execution context.</param>
+        /// <returns>The predicate to apply to the query.</returns>
         public Func<IQuery<T>, ValueTask<IQuery<T>>> Visit(NotUnaryNode node, QueryExecutionContext<T> argument)
         {
             return result => argument.Item.AllAsync(
@@ -45,6 +73,12 @@ namespace YesSql.Filters.Query.Services
             );
         }
 
+        /// <summary>
+        /// Visits an <see cref="OrNode"/> and returns the predicate to apply.
+        /// </summary>
+        /// <param name="node">The node to visit.</param>
+        /// <param name="argument">The current execution context.</param>
+        /// <returns>The predicate to apply to the query.</returns>
         public Func<IQuery<T>, ValueTask<IQuery<T>>> Visit(OrNode node, QueryExecutionContext<T> argument)
         {
             return result => argument.Item.AnyAsync(
@@ -53,6 +87,12 @@ namespace YesSql.Filters.Query.Services
             );
         }
 
+        /// <summary>
+        /// Visits an <see cref="AndNode"/> and returns the predicate to apply.
+        /// </summary>
+        /// <param name="node">The node to visit.</param>
+        /// <param name="argument">The current execution context.</param>
+        /// <returns>The predicate to apply to the query.</returns>
         public Func<IQuery<T>, ValueTask<IQuery<T>>> Visit(AndNode node, QueryExecutionContext<T> argument)
         {
             return result => argument.Item.AllAsync(
@@ -61,9 +101,21 @@ namespace YesSql.Filters.Query.Services
             );
         }
 
+        /// <summary>
+        /// Visits a <see cref="GroupNode"/> and returns the predicate to apply.
+        /// </summary>
+        /// <param name="node">The node to visit.</param>
+        /// <param name="argument">The current execution context.</param>
+        /// <returns>The predicate to apply to the query.</returns>
         public Func<IQuery<T>, ValueTask<IQuery<T>>> Visit(GroupNode node, QueryExecutionContext<T> argument)
             => node.Operation.Accept(this, argument);
 
+        /// <summary>
+        /// Visits a <see cref="TermNode"/> and returns the predicate to apply.
+        /// </summary>
+        /// <param name="node">The node to visit.</param>
+        /// <param name="argument">The current execution context.</param>
+        /// <returns>The predicate to apply to the query.</returns>
         public Func<IQuery<T>, ValueTask<IQuery<T>>> Visit(TermNode node, QueryExecutionContext<T> argument)
             => node.Accept(this, argument);
     }

--- a/src/YesSql.Filters.Query/Services/QueryParseContext.cs
+++ b/src/YesSql.Filters.Query/Services/QueryParseContext.cs
@@ -4,13 +4,26 @@ using Parlot.Fluent;
 
 namespace YesSql.Filters.Query.Services
 {
+    /// <summary>
+    /// Represents the parse context used while parsing a query filter.
+    /// </summary>
+    /// <typeparam name="T">The type of the queried document.</typeparam>
     public class QueryParseContext<T> : ParseContext where T : class
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QueryParseContext{T}"/> class.
+        /// </summary>
+        /// <param name="termOptions">The available term options.</param>
+        /// <param name="scanner">The scanner used to read the input text.</param>
+        /// <param name="useNewLines">Whether new lines are significant while parsing.</param>
         public QueryParseContext(IReadOnlyDictionary<string, QueryTermOption<T>> termOptions, Scanner scanner, bool useNewLines = false) : base(scanner, useNewLines)
         {
             TermOptions = termOptions;
         }
 
+        /// <summary>
+        /// Gets the available term options.
+        /// </summary>
         public IReadOnlyDictionary<string, QueryTermOption<T>> TermOptions { get; }
     }
 }

--- a/src/YesSql.Filters.Query/Services/QueryParser.cs
+++ b/src/YesSql.Filters.Query/Services/QueryParser.cs
@@ -6,11 +6,20 @@ using static Parlot.Fluent.Parsers;
 
 namespace YesSql.Filters.Query.Services
 {
+    /// <summary>
+    /// Parses a query filter string into a <see cref="QueryFilterResult{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the queried document.</typeparam>
     public class QueryParser<T> : IQueryParser<T> where T : class
     {
         private readonly Dictionary<string, QueryTermOption<T>> _termOptions;
         private readonly Parser<QueryFilterResult<T>> _parser;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QueryParser{T}"/> class.
+        /// </summary>
+        /// <param name="termParsers">The term parsers used to parse each term.</param>
+        /// <param name="termOptions">The available term options.</param>
         public QueryParser(Parser<TermNode>[] termParsers, Dictionary<string, QueryTermOption<T>> termOptions)
         {
             _termOptions = termOptions;
@@ -26,6 +35,11 @@ namespace YesSql.Filters.Query.Services
                     }).Compile();
         }
 
+        /// <summary>
+        /// Parses the specified text into a <see cref="QueryFilterResult{T}"/>.
+        /// </summary>
+        /// <param name="text">The query filter text to parse.</param>
+        /// <returns>The <see cref="QueryFilterResult{T}"/> produced from the parsed text.</returns>
         public QueryFilterResult<T> Parse(string text)
         {
             if (string.IsNullOrEmpty(text))

--- a/src/YesSql.Filters.Query/Services/QueryTermOption.cs
+++ b/src/YesSql.Filters.Query/Services/QueryTermOption.cs
@@ -4,20 +4,43 @@ using YesSql.Filters.Services;
 
 namespace YesSql.Filters.Query.Services
 {
+    /// <summary>
+    /// Represents the options of a query term, including the predicates applied when the term matches.
+    /// </summary>
+    /// <typeparam name="T">The type of the queried document.</typeparam>
     public class QueryTermOption<T> : TermOption where T : class
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QueryTermOption{T}"/> class.
+        /// </summary>
+        /// <param name="name">The name of the term.</param>
+        /// <param name="matchPredicate">The predicate to apply when the term matches.</param>
         public QueryTermOption(string name, Func<string, IQuery<T>, QueryExecutionContext<T>, ValueTask<IQuery<T>>> matchPredicate) : base(name)
         {
             MatchPredicate = matchPredicate;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QueryTermOption{T}"/> class.
+        /// </summary>
+        /// <param name="name">The name of the term.</param>
+        /// <param name="matchPredicate">The predicate to apply when the term matches.</param>
+        /// <param name="notMatchPredicate">The predicate to apply when the term is negated.</param>
         public QueryTermOption(string name, Func<string, IQuery<T>, QueryExecutionContext<T>, ValueTask<IQuery<T>>> matchPredicate, Func<string, IQuery<T>, QueryExecutionContext<T>, ValueTask<IQuery<T>>> notMatchPredicate)
             : base(name)
         {
             MatchPredicate = matchPredicate;
             NotMatchPredicate = notMatchPredicate;
         }
+
+        /// <summary>
+        /// Gets the predicate to apply when the term matches.
+        /// </summary>
         public Func<string, IQuery<T>, QueryExecutionContext<T>, ValueTask<IQuery<T>>> MatchPredicate { get; }
+
+        /// <summary>
+        /// Gets the predicate to apply when the term is negated.
+        /// </summary>
         public Func<string, IQuery<T>, QueryExecutionContext<T>, ValueTask<IQuery<T>>> NotMatchPredicate { get; }
     }
 }

--- a/src/YesSql.Provider.MySql/MySqlCommandInterpreter.cs
+++ b/src/YesSql.Provider.MySql/MySqlCommandInterpreter.cs
@@ -8,14 +8,26 @@ using YesSql.Sql.Schema;
 
 namespace YesSql.Provider.MySql
 {
+    /// <summary>
+    /// Represents a command interpreter that generates SQL statements for MySQL.
+    /// </summary>
     public class MySqlCommandInterpreter : BaseCommandInterpreter
     {
         private static readonly char[] Separators = { '(', ')', ' ' };
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MySqlCommandInterpreter"/> class.
+        /// </summary>
+        /// <param name="configuration">The configuration used to generate SQL statements.</param>
         public MySqlCommandInterpreter(IConfiguration configuration) : base(configuration)
         {
         }
 
+        /// <summary>
+        /// Appends the SQL statement that alters an existing column to the specified builder.
+        /// </summary>
+        /// <param name="builder">The builder to append the SQL statement to.</param>
+        /// <param name="command">The alter column command to run.</param>
         public override void Run(StringBuilder builder, IAlterColumnCommand command)
         {
             builder.AppendFormat("alter table {0} modify column {1} ",
@@ -65,6 +77,11 @@ namespace YesSql.Provider.MySql
             }
         }
 
+        /// <summary>
+        /// Appends the SQL statement that adds an index to the specified builder.
+        /// </summary>
+        /// <param name="builder">The builder to append the SQL statement to.</param>
+        /// <param name="command">The add index command to run.</param>
         public override void Run(StringBuilder builder, IAddIndexCommand command)
         {
             builder.AppendFormat("create index {1} on {0} ({2}) ",

--- a/src/YesSql.Provider.MySql/MySqlDbProviderOptionsExtensions.cs
+++ b/src/YesSql.Provider.MySql/MySqlDbProviderOptionsExtensions.cs
@@ -4,8 +4,18 @@ using System.Data;
 
 namespace YesSql.Provider.MySql
 {
+    /// <summary>
+    /// Provides extension methods on <see cref="IConfiguration"/> to configure YesSql to use the MySQL provider.
+    /// </summary>
     public static class MySqlDbProviderOptionsExtensions
     {
+        /// <summary>
+        /// Configures YesSql to use the MySQL document database provider.
+        /// </summary>
+        /// <param name="configuration">The configuration to register the provider on.</param>
+        /// <param name="connectionString">The connection string used to connect to the database.</param>
+        /// <param name="schema">The optional database schema to use.</param>
+        /// <returns>The <paramref name="configuration"/> instance to allow chaining.</returns>
         public static IConfiguration UseMySql(
             this IConfiguration configuration,
             string connectionString,
@@ -14,6 +24,14 @@ namespace YesSql.Provider.MySql
             return UseMySql(configuration, connectionString, IsolationLevel.ReadUncommitted, schema);
         }
 
+        /// <summary>
+        /// Configures YesSql to use the MySQL document database provider.
+        /// </summary>
+        /// <param name="configuration">The configuration to register the provider on.</param>
+        /// <param name="connectionString">The connection string used to connect to the database.</param>
+        /// <param name="isolationLevel">The isolation level used for transactions.</param>
+        /// <param name="schema">The optional database schema to use.</param>
+        /// <returns>The <paramref name="configuration"/> instance to allow chaining.</returns>
         public static IConfiguration UseMySql(
             this IConfiguration configuration,
             string connectionString,

--- a/src/YesSql.Provider.MySql/MySqlDialect.cs
+++ b/src/YesSql.Provider.MySql/MySqlDialect.cs
@@ -8,6 +8,9 @@ using YesSql.Utils;
 
 namespace YesSql.Provider.MySql
 {
+    /// <summary>
+    /// Represents the SQL dialect for MySQL.
+    /// </summary>
     public sealed class MySqlDialect : BaseDialect
     {
         private static readonly Dictionary<DbType, string> _columnTypes = new Dictionary<DbType, string>
@@ -83,6 +86,9 @@ namespace YesSql.Provider.MySql
             };
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MySqlDialect"/> class.
+        /// </summary>
         public MySqlDialect()
         {
             AddTypeHandler<TimeSpan, long>(x => x.Ticks);
@@ -90,14 +96,22 @@ namespace YesSql.Provider.MySql
             Methods.Add("now", new TemplateFunction("UTC_TIMESTAMP()"));
         }
 
+        /// <inheritdoc />
         public override string Name => "MySql";
+        /// <inheritdoc />
         public override string IdentitySelectString => "; select LAST_INSERT_ID()";
+        /// <inheritdoc />
         public override string IdentityLastId => "LAST_INSERT_ID()";
+        /// <inheritdoc />
         public override string IdentityColumnString => "bigint AUTO_INCREMENT primary key";
+        /// <inheritdoc />
         public override string LegacyIdentityColumnString => "int AUTO_INCREMENT primary key";
+        /// <inheritdoc />
         public override string RandomOrderByClause => "rand()";
+        /// <inheritdoc />
         public override bool SupportsIfExistsBeforeTableName => true;
 
+        /// <inheritdoc />
         public override string GetTypeName(DbType dbType, int? length, byte? precision, byte? scale)
         {
             if (length.HasValue)
@@ -165,6 +179,7 @@ namespace YesSql.Provider.MySql
             throw new Exception("DbType not found for: " + dbType);
         }
 
+        /// <inheritdoc />
         public override string FormatKeyName(string name)
         {
             // https://dev.mysql.com/doc/refman/8.0/en/identifier-length.html
@@ -177,6 +192,7 @@ namespace YesSql.Provider.MySql
             return name;
         }
 
+        /// <inheritdoc />
         public override string FormatIndexName(string name)
         {
             // https://dev.mysql.com/doc/refman/8.0/en/identifier-length.html
@@ -189,11 +205,13 @@ namespace YesSql.Provider.MySql
             return name;
         }        
 
+        /// <inheritdoc />
         public override string GetDropForeignKeyConstraintString(string name)
         {
             return " drop foreign key " + QuoteForColumnName(FormatKeyName(name));
         }
 
+        /// <inheritdoc />
         public override string GetAddForeignKeyConstraintString(string name, string[] srcColumns, string destQuotedTable, string[] destColumns, bool primaryKey)
         {
             var sql = base.GetAddForeignKeyConstraintString(name, srcColumns, destQuotedTable, destColumns, primaryKey);
@@ -206,12 +224,16 @@ namespace YesSql.Provider.MySql
             return res.ToString();
         }
 
+        /// <inheritdoc />
         public override string DefaultValuesInsert => "VALUES()";
 
+        /// <inheritdoc />
         public override byte DefaultDecimalPrecision => 65;
 
+        /// <inheritdoc />
         public override byte DefaultDecimalScale => 30;
 
+        /// <inheritdoc />
         public override void Page(ISqlBuilder sqlBuilder, string offset, string limit)
         {
             if (offset != null && limit == null)
@@ -234,27 +256,32 @@ namespace YesSql.Provider.MySql
             }
         }
 
+        /// <inheritdoc />
         public override string GetDropIndexString(string indexName, string tableName, string schema)
         {
             // This is dependent on version of MySql < v10.1.4 does not support IF EXISTS
             return "drop index " + QuoteForColumnName(indexName) + " on " + QuoteForTableName(tableName, schema);
         }
 
+        /// <inheritdoc />
         public override string QuoteForColumnName(string columnName)
         {
             return "`" + columnName + "`";
         }
 
+        /// <inheritdoc />
         public override string QuoteForTableName(string tableName, string schema)
         {
             return "`" + tableName + "`";
         }
 
+        /// <inheritdoc />
         public override string QuoteForAliasName(string aliasName)
         {
             return "`" + aliasName + "`";
         }
 
+        /// <inheritdoc />
         public override void Concat(IStringBuilder builder, params Action<IStringBuilder>[] generators)
         {
             builder.Append("concat(");
@@ -272,6 +299,7 @@ namespace YesSql.Provider.MySql
             builder.Append(")");
         }
 
+        /// <inheritdoc />
         public override string GetSqlValue(object value)
         {
             if (value == null)
@@ -287,6 +315,7 @@ namespace YesSql.Provider.MySql
             return base.GetSqlValue(value);
         }
 
+        /// <inheritdoc />
         public override string GetCreateSchemaString(string schema)
         {
             // MySQL doesn't support schemas

--- a/src/YesSql.Provider.PostgreSql/PostgreSqlCommandInterpreter.cs
+++ b/src/YesSql.Provider.PostgreSql/PostgreSqlCommandInterpreter.cs
@@ -6,12 +6,24 @@ using YesSql.Sql.Schema;
 
 namespace YesSql.Provider.PostgreSql
 {
+    /// <summary>
+    /// Represents a command interpreter that generates SQL statements for PostgreSQL.
+    /// </summary>
     public class PostgreSqlCommandInterpreter : BaseCommandInterpreter
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PostgreSqlCommandInterpreter"/> class.
+        /// </summary>
+        /// <param name="configuration">The configuration used to generate SQL statements.</param>
         public PostgreSqlCommandInterpreter(IConfiguration configuration) : base(configuration)
         {
         }
 
+        /// <summary>
+        /// Appends the SQL statement that alters an existing column to the specified builder.
+        /// </summary>
+        /// <param name="builder">The builder to append the SQL statement to.</param>
+        /// <param name="command">The alter column command to run.</param>
         public override void Run(StringBuilder builder, IAlterColumnCommand command)
         {
             builder.AppendFormat("alter table {0} alter column {1} ",

--- a/src/YesSql.Provider.PostgreSql/PostgreSqlDbProviderOptionsExtensions.cs
+++ b/src/YesSql.Provider.PostgreSql/PostgreSqlDbProviderOptionsExtensions.cs
@@ -4,11 +4,29 @@ using System.Data;
 
 namespace YesSql.Provider.PostgreSql
 {
+    /// <summary>
+    /// Provides extension methods on <see cref="IConfiguration"/> to configure YesSql to use the PostgreSQL provider.
+    /// </summary>
     public static class PostgreSqlDbProviderOptionsExtensions
     {
+        /// <summary>
+        /// Configures YesSql to use the PostgreSQL document database provider.
+        /// </summary>
+        /// <param name="configuration">The configuration to register the provider on.</param>
+        /// <param name="connectionString">The connection string used to connect to the database.</param>
+        /// <param name="schema">The optional database schema to use.</param>
+        /// <returns>The <paramref name="configuration"/> instance to allow chaining.</returns>
         public static IConfiguration UsePostgreSql(this IConfiguration configuration, string connectionString, string schema = null)
             => UsePostgreSql(configuration, connectionString, IsolationLevel.ReadUncommitted, schema);
 
+        /// <summary>
+        /// Configures YesSql to use the PostgreSQL document database provider.
+        /// </summary>
+        /// <param name="configuration">The configuration to register the provider on.</param>
+        /// <param name="connectionString">The connection string used to connect to the database.</param>
+        /// <param name="isolationLevel">The isolation level used for transactions.</param>
+        /// <param name="schema">The optional database schema to use.</param>
+        /// <returns>The <paramref name="configuration"/> instance to allow chaining.</returns>
         public static IConfiguration UsePostgreSql(this IConfiguration configuration, string connectionString, IsolationLevel isolationLevel, string schema = null)
         {
             ArgumentNullException.ThrowIfNull(configuration);

--- a/src/YesSql.Provider.PostgreSql/PostgreSqlDialect.cs
+++ b/src/YesSql.Provider.PostgreSql/PostgreSqlDialect.cs
@@ -7,6 +7,9 @@ using YesSql.Utils;
 
 namespace YesSql.Provider.PostgreSql
 {
+    /// <summary>
+    /// Represents the SQL dialect for PostgreSQL.
+    /// </summary>
     public sealed class PostgreSqlDialect : BaseDialect
     {
         private static readonly Dictionary<DbType, string> _columnTypes = new Dictionary<DbType, string>
@@ -83,6 +86,9 @@ namespace YesSql.Provider.PostgreSql
             };
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PostgreSqlDialect"/> class.
+        /// </summary>
         public PostgreSqlDialect()
         {
             AddTypeHandler<TimeSpan, long>(x => x.Ticks);
@@ -104,16 +110,27 @@ namespace YesSql.Provider.PostgreSql
             Methods.Add("now", new TemplateFunction("now() at time zone 'utc'"));
         }
 
+        /// <inheritdoc />
         public override string Name => "PostgreSql";
+        /// <inheritdoc />
         public override string InOperator(string values) => " = any(array[" + values + "])";
+        /// <inheritdoc />
         public override string NotInOperator(string values) => " <> all(array[" + values + "])";
+        /// <inheritdoc />
         public override string IdentitySelectString => "RETURNING";
+        /// <inheritdoc />
         public override string IdentityLastId => $"lastval()";
+        /// <inheritdoc />
         public override string IdentityColumnString => "BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY";
+        /// <inheritdoc />
         public override string LegacyIdentityColumnString => "INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY";
+        /// <inheritdoc />
         public override string RandomOrderByClause => "random()";
+        /// <inheritdoc />
         public override bool SupportsIfExistsBeforeTableName => true;
+        /// <inheritdoc />
         public override bool PrefixIndex => true;
+        /// <inheritdoc />
         public override string GetTypeName(DbType dbType, int? length, byte? precision, byte? scale)
         {
             if (length.HasValue)
@@ -157,6 +174,7 @@ namespace YesSql.Provider.PostgreSql
             throw new Exception("DbType not found for: " + dbType);
         }
 
+        /// <inheritdoc />
         public override string FormatKeyName(string name)
         {
             // https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
@@ -169,6 +187,7 @@ namespace YesSql.Provider.PostgreSql
             return name;
         }
         
+        /// <inheritdoc />
         public override string FormatIndexName(string name)
         {
             // https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
@@ -180,13 +199,16 @@ namespace YesSql.Provider.PostgreSql
 
             return name;
         }  
+        /// <inheritdoc />
         public override string GetDropForeignKeyConstraintString(string name)
         {
             return " drop constraint " + QuoteForColumnName(name);
         }
 
+        /// <inheritdoc />
         public override string DefaultValuesInsert => "DEFAULT VALUES";
 
+        /// <inheritdoc />
         public override void Page(ISqlBuilder sqlBuilder, string offset, string limit)
         {
             sqlBuilder.Trail(" limit ");
@@ -208,16 +230,19 @@ namespace YesSql.Provider.PostgreSql
             }
         }
 
+        /// <inheritdoc />
         public override string GetDropIndexString(string indexName, string tableName, string schema)
         {
             return "drop index if exists " + QuoteForColumnName(indexName);
         }
 
+        /// <inheritdoc />
         public override string QuoteForColumnName(string columnName)
         {
             return QuoteString + columnName + QuoteString;
         }
 
+        /// <inheritdoc />
         public override string QuoteForTableName(string tableName, string schema)
         {
             return string.IsNullOrEmpty(schema)
@@ -226,17 +251,22 @@ namespace YesSql.Provider.PostgreSql
                 ;
         }
 
+        /// <inheritdoc />
         public override string QuoteForAliasName(string aliasName)
         {
             return QuoteString + aliasName + QuoteString;
         }
 
+        /// <inheritdoc />
         public override string CascadeConstraintsString => " cascade ";
 
+        /// <inheritdoc />
         public override byte DefaultDecimalPrecision => 19;
 
+        /// <inheritdoc />
         public override byte DefaultDecimalScale => 5;
 
+        /// <inheritdoc />
         public override string GetSqlValue(object value)
         {
             if (value == null)
@@ -265,6 +295,7 @@ namespace YesSql.Provider.PostgreSql
             }
         }
 
+        /// <inheritdoc />
         public override string GetCreateSchemaString(string schema)
         {
             return $"CREATE SCHEMA IF NOT EXISTS {QuoteForColumnName(schema)}";

--- a/src/YesSql.Provider.SqlServer/SqlServerComandInterpreter.cs
+++ b/src/YesSql.Provider.SqlServer/SqlServerComandInterpreter.cs
@@ -4,12 +4,24 @@ using YesSql.Sql.Schema;
 
 namespace YesSql.Provider.SqlServer
 {
+    /// <summary>
+    /// Represents a command interpreter that generates SQL statements for SQL Server.
+    /// </summary>
     public class SqlServerCommandInterpreter : BaseCommandInterpreter
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqlServerCommandInterpreter"/> class.
+        /// </summary>
+        /// <param name="configuration">The configuration used to generate SQL statements.</param>
         public SqlServerCommandInterpreter(IConfiguration configuration) : base(configuration)
         {
         }
 
+        /// <summary>
+        /// Appends the SQL statement that renames an existing column to the specified builder.
+        /// </summary>
+        /// <param name="builder">The builder to append the SQL statement to.</param>
+        /// <param name="command">The rename column command to run.</param>
         public override void Run(StringBuilder builder, IRenameColumnCommand command)
         {
             builder.AppendFormat("EXEC sp_RENAME {0}, {1}, 'COLUMN'",

--- a/src/YesSql.Provider.SqlServer/SqlServerDbProviderOptionsExtensions.cs
+++ b/src/YesSql.Provider.SqlServer/SqlServerDbProviderOptionsExtensions.cs
@@ -4,8 +4,18 @@ using System.Data;
 
 namespace YesSql.Provider.SqlServer
 {
+    /// <summary>
+    /// Provides extension methods on <see cref="IConfiguration"/> to configure YesSql to use the SQL Server provider.
+    /// </summary>
     public static class SqlServerDbProviderOptionsExtensions
     {
+        /// <summary>
+        /// Configures YesSql to use the SQL Server document database provider.
+        /// </summary>
+        /// <param name="configuration">The configuration to register the provider on.</param>
+        /// <param name="connectionString">The connection string used to connect to the database.</param>
+        /// <param name="schema">The optional database schema to use.</param>
+        /// <returns>The <paramref name="configuration"/> instance to allow chaining.</returns>
         public static IConfiguration UseSqlServer(
             this IConfiguration configuration,
             string connectionString,
@@ -14,6 +24,14 @@ namespace YesSql.Provider.SqlServer
             return UseSqlServer(configuration, connectionString, IsolationLevel.ReadUncommitted, schema);
         }
 
+        /// <summary>
+        /// Configures YesSql to use the SQL Server document database provider.
+        /// </summary>
+        /// <param name="configuration">The configuration to register the provider on.</param>
+        /// <param name="connectionString">The connection string used to connect to the database.</param>
+        /// <param name="isolationLevel">The isolation level used for transactions.</param>
+        /// <param name="schema">The optional database schema to use.</param>
+        /// <returns>The <paramref name="configuration"/> instance to allow chaining.</returns>
         public static IConfiguration UseSqlServer(
             this IConfiguration configuration,
             string connectionString,

--- a/src/YesSql.Provider.SqlServer/SqlServerDialect.cs
+++ b/src/YesSql.Provider.SqlServer/SqlServerDialect.cs
@@ -6,6 +6,9 @@ using YesSql.Sql;
 
 namespace YesSql.Provider.SqlServer
 {
+    /// <summary>
+    /// Represents the SQL dialect for SQL Server.
+    /// </summary>
     public class SqlServerDialect : BaseDialect
     {
         private static readonly Dictionary<DbType, string> _columnTypes = new()
@@ -82,6 +85,9 @@ namespace YesSql.Provider.SqlServer
             };
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqlServerDialect"/> class.
+        /// </summary>
         public SqlServerDialect()
         {
             AddTypeHandler<TimeSpan, long>(x => x.Ticks);
@@ -97,15 +103,24 @@ namespace YesSql.Provider.SqlServer
             //Methods.Add("year", new TemplateFunction("datepart(year, {0})"));
         }
 
+        /// <inheritdoc />
         public override string Name => "SqlServer";
+        /// <inheritdoc />
         public override string IdentityColumnString => "[BIGINT] IDENTITY(1,1) primary key";
+        /// <inheritdoc />
         public override string LegacyIdentityColumnString => "[INT] IDENTITY(1,1) primary key";
+        /// <inheritdoc />
         public override string IdentitySelectString => "; select SCOPE_IDENTITY()";
+        /// <inheritdoc />
         public override string IdentityLastId => "SCOPE_IDENTITY()";
+        /// <inheritdoc />
         public override string RandomOrderByClause => "newid()";
+        /// <inheritdoc />
         public override byte DefaultDecimalPrecision => 19;
+        /// <inheritdoc />
         public override byte DefaultDecimalScale => 5;
 
+        /// <inheritdoc />
         public override string GetTypeName(DbType dbType, int? length, byte? precision, byte? scale)
         {
             if (length.HasValue)
@@ -169,6 +184,7 @@ namespace YesSql.Provider.SqlServer
             throw new Exception("DbType not found for: " + dbType);
         }
 
+        /// <inheritdoc />
         public override void Page(ISqlBuilder sqlBuilder, string offset, string limit)
         {
             if (offset != null)
@@ -193,16 +209,19 @@ namespace YesSql.Provider.SqlServer
             }
         }
 
+        /// <inheritdoc />
         public override string GetDropIndexString(string indexName, string tableName, string schema)
         {
             return "drop index if exists " + QuoteForColumnName(indexName) + " on " + QuoteForTableName(tableName, schema);
         }
 
+        /// <inheritdoc />
         public override string QuoteForColumnName(string columnName)
         {
             return "[" + columnName + "]";
         }
 
+        /// <inheritdoc />
         public override string QuoteForTableName(string tableName, string schema)
         {
             return string.IsNullOrEmpty(schema)
@@ -211,11 +230,13 @@ namespace YesSql.Provider.SqlServer
                 ;
         }
 
+        /// <inheritdoc />
         public override string QuoteForAliasName(string aliasName)
         {
             return "[" + aliasName + "]";
         }
 
+        /// <inheritdoc />
         public override void Concat(IStringBuilder builder, params Action<IStringBuilder>[] generators)
         {
             builder.Append("(");
@@ -233,11 +254,13 @@ namespace YesSql.Provider.SqlServer
             builder.Append(")");
         }
 
+        /// <inheritdoc />
         protected override string Quote(string value)
         {
             return "N" + SingleQuoteString + value.Replace(SingleQuoteString, DoubleSingleQuoteString) + SingleQuoteString;
         }
         
+        /// <inheritdoc />
         public override string GetSqlValue(object value)
         {
             if (value == null)
@@ -253,10 +276,13 @@ namespace YesSql.Provider.SqlServer
             return base.GetSqlValue(value);
         }
 
+        /// <inheritdoc />
         public override bool SupportsIfExistsBeforeTableName => true;
 
+        /// <inheritdoc />
         public override int MaxParametersPerCommand => 2098;
 
+        /// <inheritdoc />
         public override string GetCreateSchemaString(string schema)
         {
             return $"IF NOT EXISTS ( SELECT * FROM sys.schemas WHERE name = N'{schema}' ) EXEC('CREATE SCHEMA [{schema}]');";

--- a/src/YesSql.Provider.Sqlite/SqliteCommandInterpreter.cs
+++ b/src/YesSql.Provider.Sqlite/SqliteCommandInterpreter.cs
@@ -4,17 +4,34 @@ using YesSql.Sql.Schema;
 
 namespace YesSql.Provider.Sqlite
 {
+    /// <summary>
+    /// Represents a command interpreter that generates SQL statements for SQLite.
+    /// </summary>
     public class SqliteCommandInterpreter : BaseCommandInterpreter
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqliteCommandInterpreter"/> class.
+        /// </summary>
+        /// <param name="configuration">The configuration used to generate SQL statements.</param>
         public SqliteCommandInterpreter(IConfiguration configuration) : base(configuration)
         {
         }
 
+        /// <summary>
+        /// Generates the SQL statements for the specified create foreign key command.
+        /// </summary>
+        /// <param name="command">The create foreign key command to run.</param>
+        /// <returns>An empty sequence, as SQLite does not support adding foreign keys to existing tables.</returns>
         public override IEnumerable<string> Run(ICreateForeignKeyCommand command)
         {
             yield break;
         }
 
+        /// <summary>
+        /// Generates the SQL statements for the specified drop foreign key command.
+        /// </summary>
+        /// <param name="command">The drop foreign key command to run.</param>
+        /// <returns>An empty sequence, as SQLite does not support dropping foreign keys from existing tables.</returns>
         public override IEnumerable<string> Run(IDropForeignKeyCommand command)
         {
             yield break;

--- a/src/YesSql.Provider.Sqlite/SqliteDbProviderOptionsExtensions.cs
+++ b/src/YesSql.Provider.Sqlite/SqliteDbProviderOptionsExtensions.cs
@@ -4,11 +4,27 @@ using System.Data;
 
 namespace YesSql.Provider.Sqlite
 {
+    /// <summary>
+    /// Provides extension methods on <see cref="IConfiguration"/> to configure YesSql to use the SQLite provider.
+    /// </summary>
     public static class SqliteDbProviderOptionsExtensions
     {
+        /// <summary>
+        /// Configures YesSql to use the SQLite document database provider.
+        /// </summary>
+        /// <param name="configuration">The configuration to register the provider on.</param>
+        /// <param name="connectionString">The connection string used to connect to the database.</param>
+        /// <returns>The <paramref name="configuration"/> instance to allow chaining.</returns>
         public static IConfiguration UseSqLite(this IConfiguration configuration, string connectionString)
             => UseSqLite(configuration, connectionString, IsolationLevel.Serializable);
 
+        /// <summary>
+        /// Configures YesSql to use the SQLite document database provider.
+        /// </summary>
+        /// <param name="configuration">The configuration to register the provider on.</param>
+        /// <param name="connectionString">The connection string used to connect to the database.</param>
+        /// <param name="isolationLevel">The isolation level used for transactions.</param>
+        /// <returns>The <paramref name="configuration"/> instance to allow chaining.</returns>
         public static IConfiguration UseSqLite(this IConfiguration configuration, string connectionString, IsolationLevel isolationLevel)
         {
             ArgumentNullException.ThrowIfNull(configuration);

--- a/src/YesSql.Provider.Sqlite/SqliteDialect.cs
+++ b/src/YesSql.Provider.Sqlite/SqliteDialect.cs
@@ -5,6 +5,9 @@ using YesSql.Sql;
 
 namespace YesSql.Provider.Sqlite
 {
+    /// <summary>
+    /// Represents the SQL dialect for SQLite.
+    /// </summary>
     public sealed class SqliteDialect : BaseDialect
     {
         private static readonly Dictionary<DbType, string> _columnTypes = new Dictionary<DbType, string>
@@ -82,6 +85,9 @@ namespace YesSql.Provider.Sqlite
             };
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqliteDialect"/> class.
+        /// </summary>
         public SqliteDialect()
         {
             // Add type handlers for cross-type DateTime/DateTimeOffset compatibility
@@ -97,19 +103,28 @@ namespace YesSql.Provider.Sqlite
             Methods.Add("now", new TemplateFunction("DATETIME('now')"));
         }
 
+        /// <inheritdoc />
         public override string Name => "Sqlite";
 
+        /// <inheritdoc />
         public override string IdentityColumnString => "integer primary key autoincrement";
+        /// <inheritdoc />
         public override string LegacyIdentityColumnString => "integer primary key autoincrement";
+        /// <inheritdoc />
         public override string IdentitySelectString => "; select last_insert_rowid()";
+        /// <inheritdoc />
         public override string IdentityLastId => "last_insert_rowid()";
 
+        /// <inheritdoc />
         public override string RandomOrderByClause => "random()";
 
+        /// <inheritdoc />
         public override byte DefaultDecimalPrecision => 19;
 
+        /// <inheritdoc />
         public override byte DefaultDecimalScale => 5;
 
+        /// <inheritdoc />
         public override string GetTypeName(DbType dbType, int? length, byte? precision, byte? scale)
         {
             if (_columnTypes.TryGetValue(dbType, out var value))
@@ -120,6 +135,7 @@ namespace YesSql.Provider.Sqlite
             throw new Exception("DbType not found for: " + dbType);
         }
 
+        /// <inheritdoc />
         public override void Page(ISqlBuilder sqlBuilder, string offset, string limit)
         {
             sqlBuilder.ClearTrail();
@@ -143,33 +159,40 @@ namespace YesSql.Provider.Sqlite
             }
         }
 
+        /// <inheritdoc />
         public override string GetDropIndexString(string indexName, string tableName, string schema)
         {
             return "drop index if exists " + QuoteForColumnName(indexName);
         }
 
+        /// <inheritdoc />
         public override string QuoteForColumnName(string columnName)
         {
             return "[" + columnName + "]";
         }
 
+        /// <inheritdoc />
         public override string QuoteForTableName(string tableName, string schema)
         {
             return "[" + tableName + "]";
         }
 
+        /// <inheritdoc />
         public override string QuoteForAliasName(string aliasName)
         {
             return aliasName;
         }
 
+        /// <inheritdoc />
         public override bool SupportsIfExistsBeforeTableName => true;
 
+        /// <inheritdoc />
         public override string GetCreateSchemaString(string schema)
         {
             return null;
         }
 
+        /// <inheritdoc />
         public override IEnumerable<(string aggregate, string alias)> GetAggregateOrders(IList<string> select, IList<string> orderBy)
         {
             // Most databases (MySql, PostgreSql and SqlServer) require all ordered fields to be part of the select when GROUP BY (or DISTINCT) is used


### PR DESCRIPTION
## Why

The packable public-API projects set `GenerateDocumentationFile=true`, so they ship a `.xml` docs file with the NuGet packages. But CS1591 (missing XML comment) was suppressed in `Directory.Build.props`, which masked the fact that **531 publicly visible types and members had no XML documentation**. As a result, IntelliSense and the published API docs were largely empty for these assemblies.

## What

Adds XML doc comments to every undocumented public member across the public-API surface:

- **YesSql.Abstractions** - 253
- **YesSql.Filters.Abstractions** - 122
- **YesSql.Filters.Query** - 37
- **YesSql.Provider.PostgreSql / MySql / SqlServer / Sqlite** - 33 / 32 / 28 / 26

The comments follow the existing house style already used in files like `ISession.cs` and `IConfiguration.cs`: third-person summaries, `<param>`/`<returns>`/`<typeparam>`, `<see cref>` cross-references, `<inheritdoc/>` on interface implementations, and `<c>true</c>`/`<c>false</c>` for booleans. Provider docs are kept consistent across all four databases (same wording, adjusted for the DB name).

## Notes for reviewers

- The change is **purely additive**: 94 files, 2039 insertions, 0 deletions. No code behavior changes.
- `YesSql.Core` is intentionally left out because it sets `GenerateDocumentationFile=false`; the public contract lives in `YesSql.Abstractions`.
- CS1591 remains suppressed in the build settings (unchanged) - I only used it temporarily during development to enumerate the gaps. A solution build with the original warnings-as-errors settings passes, and the generated XML doc files are now complete.