### PR TITLE
Fix pre-release correctness bugs and robustness issues

### DIFF
--- a/src/YesSql.Core/Commands/DeleteReduceIndexCommand.cs
+++ b/src/YesSql.Core/Commands/DeleteReduceIndexCommand.cs
@@ -51,7 +51,7 @@ namespace YesSql.Commands
             {
                 logger.LogTrace(command);
             }
-            await connection.ExecuteAsync(command, new { Id = Index.Id }, transaction);
+            await connection.ExecuteAsync(new CommandDefinition(command, new { Id = Index.Id }, transaction, null, null, CommandFlags.Buffered, cancellationToken));
         }
     }
 }

--- a/src/YesSql.Core/Commands/UpdateIndexCommand.cs
+++ b/src/YesSql.Core/Commands/UpdateIndexCommand.cs
@@ -61,7 +61,7 @@ namespace YesSql.Commands
                     {
                         logger.LogTrace(bridgeSqlAdd);
                     }
-                    await connection.ExecuteAsync(bridgeSqlAdd, dynamicParamsAdded, transaction);
+                    await connection.ExecuteAsync(new CommandDefinition(bridgeSqlAdd, dynamicParamsAdded, transaction, null, null, CommandFlags.Buffered, cancellationToken));
                 }
 
                 if (_deletedDocumentIds.Length > 0)
@@ -76,7 +76,7 @@ namespace YesSql.Commands
                     {
                         logger.LogTrace(bridgeSqlRemove);
                     }
-                    await connection.ExecuteAsync(bridgeSqlRemove, dynamicParamsDeleted, transaction);
+                    await connection.ExecuteAsync(new CommandDefinition(bridgeSqlRemove, dynamicParamsDeleted, transaction, null, null, CommandFlags.Buffered, cancellationToken));
                 }
             }
         }

--- a/src/YesSql.Core/Data/NullableThumbprintFactory.cs
+++ b/src/YesSql.Core/Data/NullableThumbprintFactory.cs
@@ -58,7 +58,8 @@ namespace YesSql.Data
             // Each type gets a unique type index
             _typeIndex = Interlocked.Increment(ref _globalTypeIndex);
 
-            if (_globalTypeIndex > MaxTypeIndex)
+            // Type indices start at 1, so only MaxTypeIndex - 1 distinct values fit in the 16 reserved bits.
+            if (_typeIndex >= MaxTypeIndex)
             {
                 throw new InvalidOperationException("The maximum number of compiled queries was reached");
             }

--- a/src/YesSql.Core/Data/WorkerQueryKey.cs
+++ b/src/YesSql.Core/Data/WorkerQueryKey.cs
@@ -75,7 +75,7 @@ namespace YesSql.Data
                 return SameIds(_ids, other._ids);
             }
 
-            return true;
+            return _id == other._id;
         }
 
         private int BuildHashCode()

--- a/src/YesSql.Core/Session.cs
+++ b/src/YesSql.Core/Session.cs
@@ -883,29 +883,52 @@ namespace YesSql
                 // Can the command be batched
                 if (command.AddToBatch(_dialect, localQueries, localDbCommand, localActions, index))
                 {
-                    // Does it go over the page or parameters limits
+                    // A single command that on its own exceeds the batch limits can never fit into any
+                    // batch. Adding it would produce an oversized batch that fails at execution time, so
+                    // it must be executed individually instead.
+                    var exceedsByItself =
+                        localQueries.Count > _store.Configuration.CommandsPageSize ||
+                        localDbCommand.Parameters.Count > _store.Configuration.SqlDialect.MaxParametersPerCommand;
 
-                    var tooManyQueries = batch.Queries.Count + localQueries.Count > _store.Configuration.CommandsPageSize;
-                    var tooManyCommands = batch.Command.Parameters.Count + localDbCommand.Parameters.Count > _store.Configuration.SqlDialect.MaxParametersPerCommand;
-
-                    if (tooManyQueries || tooManyCommands)
+                    if (exceedsByItself)
                     {
-                        batches.Add(batch);
+                        // Finalize the current batch before running this command on its own
+                        if (batch.Queries.Count > 0)
+                        {
+                            batches.Add(batch);
 
-                        // Then start a new batch
-                        batch = new BatchCommand(_connection.CreateCommand());
+                            // Then start a new batch
+                            batch = new BatchCommand(_connection.CreateCommand());
+                        }
+
+                        batches.Add(command);
                     }
-
-                    // We can add the queries to the current batch
-                    batch.Queries.AddRange(localQueries);
-                    batch.Actions.AddRange(localActions);
-                    for (var i = localDbCommand.Parameters.Count - 1; i >= 0; i--)
+                    else
                     {
-                        // npgsql will prevent a parameter from being added to a collection
-                        // if it's already in another one
-                        var parameter = localDbCommand.Parameters[i];
-                        localDbCommand.Parameters.RemoveAt(i);
-                        batch.Command.Parameters.Add(parameter);
+                        // Does it go over the page or parameters limits
+
+                        var tooManyQueries = batch.Queries.Count + localQueries.Count > _store.Configuration.CommandsPageSize;
+                        var tooManyCommands = batch.Command.Parameters.Count + localDbCommand.Parameters.Count > _store.Configuration.SqlDialect.MaxParametersPerCommand;
+
+                        if (tooManyQueries || tooManyCommands)
+                        {
+                            batches.Add(batch);
+
+                            // Then start a new batch
+                            batch = new BatchCommand(_connection.CreateCommand());
+                        }
+
+                        // We can add the queries to the current batch
+                        batch.Queries.AddRange(localQueries);
+                        batch.Actions.AddRange(localActions);
+                        for (var i = localDbCommand.Parameters.Count - 1; i >= 0; i--)
+                        {
+                            // npgsql will prevent a parameter from being added to a collection
+                            // if it's already in another one
+                            var parameter = localDbCommand.Parameters[i];
+                            localDbCommand.Parameters.RemoveAt(i);
+                            batch.Command.Parameters.Add(parameter);
+                        }
                     }
                 }
                 else

--- a/src/YesSql.Core/Sql/BaseComandInterpreter.cs
+++ b/src/YesSql.Core/Sql/BaseComandInterpreter.cs
@@ -121,6 +121,15 @@ namespace YesSql.Sql
                 yield break;
             }
 
+            // drop index
+            // Indexes are dropped first so columns they reference can subsequently be dropped or altered.
+            foreach (var dropIndex in command.TableCommands.OfType<DropIndexCommand>())
+            {
+                var builder = new StringBuilder();
+                Run(builder, dropIndex);
+                yield return builder.ToString();
+            }
+
             // drop columns
             foreach (var dropColumn in command.TableCommands.OfType<DropColumnCommand>())
             {
@@ -154,18 +163,11 @@ namespace YesSql.Sql
             }
 
             // add index
+            // Indexes are added last so they reference the final column layout.
             foreach (var addIndex in command.TableCommands.OfType<AddIndexCommand>())
             {
                 var builder = new StringBuilder();
                 Run(builder, addIndex);
-                yield return builder.ToString();
-            }
-
-            // drop index
-            foreach (var dropIndex in command.TableCommands.OfType<DropIndexCommand>())
-            {
-                var builder = new StringBuilder();
-                Run(builder, dropIndex);
                 yield return builder.ToString();
             }
         }

--- a/src/YesSql.Core/Sql/SchemaBuilder.cs
+++ b/src/YesSql.Core/Sql/SchemaBuilder.cs
@@ -59,9 +59,9 @@ namespace YesSql.Sql
                     table.CreateIndex($"IDX_FK_{indexTable}", "DocumentId")
                     );
             }
-            catch
+            catch (Exception e)
             {
-                if (ThrowOnError)
+                if (ThrowOnError || e is not DbException)
                 {
                     throw;
                 }
@@ -99,9 +99,9 @@ namespace YesSql.Sql
                     table.CreateIndex($"IDX_FK_{bridgeTableName}", indexName + "Id", "DocumentId")
                     );
             }
-            catch
+            catch (Exception e)
             {
-                if (ThrowOnError)
+                if (ThrowOnError || e is not DbException)
                 {
                     throw;
                 }
@@ -126,9 +126,9 @@ namespace YesSql.Sql
                 await DropTableAsync(bridgeTableName);
                 await DropTableAsync(indexTable);
             }
-            catch
+            catch (Exception e)
             {
-                if (ThrowOnError)
+                if (ThrowOnError || e is not DbException)
                 {
                     throw;
                 }
@@ -149,9 +149,9 @@ namespace YesSql.Sql
 
                 await DropTableAsync(indexTable);
             }
-            catch
+            catch (Exception e)
             {
-                if (ThrowOnError)
+                if (ThrowOnError || e is not DbException)
                 {
                     throw;
                 }
@@ -166,9 +166,9 @@ namespace YesSql.Sql
                 table(createTable);
                 await ExecuteAsync(_commandInterpreter.CreateSql(createTable));
             }
-            catch
+            catch (Exception e)
             {
-                if (ThrowOnError)
+                if (ThrowOnError || e is not DbException)
                 {
                     throw;
                 }
@@ -183,9 +183,9 @@ namespace YesSql.Sql
                 table(alterTable);
                 await ExecuteAsync(_commandInterpreter.CreateSql(alterTable));
             }
-            catch
+            catch (Exception e)
             {
-                if (ThrowOnError)
+                if (ThrowOnError || e is not DbException)
                 {
                     throw;
                 }
@@ -205,9 +205,9 @@ namespace YesSql.Sql
                 var deleteTable = new DropTableCommand(Prefix(name));
                 await ExecuteAsync(_commandInterpreter.CreateSql(deleteTable));
             }
-            catch
+            catch (Exception e)
             {
-                if (ThrowOnError)
+                if (ThrowOnError || e is not DbException)
                 {
                     throw;
                 }
@@ -222,9 +222,9 @@ namespace YesSql.Sql
                 var sql = _commandInterpreter.CreateSql(command);
                 await ExecuteAsync(sql);
             }
-            catch
+            catch (Exception e)
             {
-                if (ThrowOnError)
+                if (ThrowOnError || e is not DbException)
                 {
                     throw;
                 }
@@ -238,9 +238,9 @@ namespace YesSql.Sql
                 var command = new DropForeignKeyCommand(Dialect.FormatKeyName(Prefix(srcTable)), Prefix(name));
                 await ExecuteAsync(_commandInterpreter.CreateSql(command));
             }
-            catch
+            catch (Exception e)
             {
-                if (ThrowOnError)
+                if (ThrowOnError || e is not DbException)
                 {
                     throw;
                 }
@@ -254,9 +254,9 @@ namespace YesSql.Sql
                 var createSchema = new CreateSchemaCommand(schema);
                 await ExecuteAsync(_commandInterpreter.CreateSql(createSchema));
             }
-            catch
+            catch (Exception e)
             {
-                if (ThrowOnError)
+                if (ThrowOnError || e is not DbException)
                 {
                     throw;
                 }

--- a/src/YesSql.Core/Sql/SqlBuilder.cs
+++ b/src/YesSql.Core/Sql/SqlBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using YesSql.Utils;
 
 namespace YesSql.Sql
@@ -463,10 +464,12 @@ namespace YesSql.Sql
                 _from = _from == null ? null : new List<string>(_from),
                 _join = _join == null ? null : new List<string>(_join),
                 _where = _where == null ? null : new List<string>(_where),
+                _or = _or == null ? null : _or.Select(o => new List<string>(o)).ToList(),
                 _group = _group == null ? null : new List<string>(_group),
                 _having = _having == null ? null : new List<string>(_having),
                 _order = _order == null ? null : new List<string>(_order),
                 _trail = _trail == null ? null : new List<string>(_trail),
+                _distinct = _distinct,
                 _skip = _skip,
                 _count = _count,
 

--- a/src/YesSql.Filters.Query/Services/QueryFilterVisitor.cs
+++ b/src/YesSql.Filters.Query/Services/QueryFilterVisitor.cs
@@ -35,6 +35,14 @@ namespace YesSql.Filters.Query.Services
                 currentQuery = argument.CurrentTermOption.NotMatchPredicate;
             }
 
+            if (currentQuery == null)
+            {
+                throw new InvalidOperationException(
+                    "The term does not define a "
+                    + (node.UseMatch ? "match" : "negated (NOT) match")
+                    + " predicate.");
+            }
+
             return result => currentQuery(node.Value, argument.Item, argument);
         }
 

--- a/test/YesSql.Tests/CommandInterpreterTests.cs
+++ b/test/YesSql.Tests/CommandInterpreterTests.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using YesSql.Provider.Sqlite;
+using YesSql.Sql;
+using YesSql.Sql.Schema;
+
+namespace YesSql.Tests
+{
+    public class CommandInterpreterTests
+    {
+        private static (SqliteCommandInterpreter Interpreter, SqliteDialect Dialect) CreateInterpreter()
+        {
+            var dialect = new SqliteDialect();
+            var configuration = new Configuration
+            {
+                SqlDialect = dialect
+            };
+
+            return (new SqliteCommandInterpreter(configuration), dialect);
+        }
+
+        [Fact]
+        public void AlterTableShouldDropIndexBeforeAddingIndex()
+        {
+            var (interpreter, dialect) = CreateInterpreter();
+
+            var alter = new AlterTableCommand("People", dialect, "tp_");
+
+            // Order of registration intentionally puts the add before the drop to
+            // verify the interpreter reorders them.
+            alter.CreateIndex("IDX_New", "Name");
+            alter.DropIndex("IDX_Old");
+
+            var statements = interpreter.Run(alter).ToList();
+
+            var dropIndex = statements.FindIndex(s => s.Contains("drop index"));
+            var createIndex = statements.FindIndex(s => s.Contains("create index"));
+
+            Assert.True(dropIndex >= 0, "Expected a drop index statement.");
+            Assert.True(createIndex >= 0, "Expected a create index statement.");
+            Assert.True(dropIndex < createIndex, "Drop index must be emitted before create index.");
+        }
+
+        [Fact]
+        public void AlterTableShouldDropIndexBeforeDroppingColumns()
+        {
+            var (interpreter, dialect) = CreateInterpreter();
+
+            var alter = new AlterTableCommand("People", dialect, "tp_");
+
+            alter.DropColumn("Name");
+            alter.DropIndex("IDX_Name");
+
+            var statements = interpreter.Run(alter).ToList();
+
+            var dropIndex = statements.FindIndex(s => s.Contains("drop index"));
+            var dropColumn = statements.FindIndex(s => s.Contains("drop column"));
+
+            Assert.True(dropIndex >= 0, "Expected a drop index statement.");
+            Assert.True(dropColumn >= 0, "Expected a drop column statement.");
+            Assert.True(dropIndex < dropColumn, "Drop index must be emitted before drop column.");
+        }
+    }
+}

--- a/test/YesSql.Tests/Filters/QueryFilterVisitorTests.cs
+++ b/test/YesSql.Tests/Filters/QueryFilterVisitorTests.cs
@@ -1,0 +1,63 @@
+using System;
+using Xunit;
+using YesSql.Filters.Nodes;
+using YesSql.Filters.Query.Services;
+using YesSql.Tests.Models;
+
+namespace YesSql.Tests.Filters
+{
+    public class QueryFilterVisitorTests
+    {
+        [Fact]
+        public void ShouldThrowWhenMatchPredicateIsMissing()
+        {
+            var visitor = new QueryFilterVisitor<Person>();
+            var context = new QueryExecutionContext<Person>(null)
+            {
+                // A term option with no match predicate.
+                CurrentTermOption = new QueryTermOption<Person>("name", matchPredicate: null)
+            };
+
+            var node = new UnaryNode("steve", OperateNodeQuotes.None, useMatch: true);
+
+            Assert.Throws<InvalidOperationException>(() => visitor.Visit(node, context));
+        }
+
+        [Fact]
+        public void ShouldThrowWhenNotMatchPredicateIsMissing()
+        {
+            var visitor = new QueryFilterVisitor<Person>();
+            var context = new QueryExecutionContext<Person>(null)
+            {
+                // A term option with a match predicate but no negated predicate.
+                CurrentTermOption = new QueryTermOption<Person>(
+                    "name",
+                    matchPredicate: (value, query, ctx) => new System.Threading.Tasks.ValueTask<IQuery<Person>>(query),
+                    notMatchPredicate: null)
+            };
+
+            var node = new UnaryNode("steve", OperateNodeQuotes.None, useMatch: false);
+
+            Assert.Throws<InvalidOperationException>(() => visitor.Visit(node, context));
+        }
+
+        [Fact]
+        public void ShouldNotThrowWhenMatchPredicateIsPresent()
+        {
+            var visitor = new QueryFilterVisitor<Person>();
+            var context = new QueryExecutionContext<Person>(null)
+            {
+                CurrentTermOption = new QueryTermOption<Person>(
+                    "name",
+                    matchPredicate: (value, query, ctx) => new System.Threading.Tasks.ValueTask<IQuery<Person>>(query))
+            };
+
+            var node = new UnaryNode("steve", OperateNodeQuotes.None, useMatch: true);
+
+            // Visiting builds the predicate delegate without evaluating it; it must not throw.
+            var result = visitor.Visit(node, context);
+
+            Assert.NotNull(result);
+        }
+    }
+}

--- a/test/YesSql.Tests/SqlBuilderTests.cs
+++ b/test/YesSql.Tests/SqlBuilderTests.cs
@@ -1,0 +1,54 @@
+using Xunit;
+using YesSql.Provider.Sqlite;
+using YesSql.Sql;
+
+namespace YesSql.Tests
+{
+    public class SqlBuilderTests
+    {
+        private static SqlBuilder CreateSelectBuilder()
+        {
+            var builder = new SqlBuilder("tp_", new SqliteDialect());
+            builder.Select();
+            builder.AddSelector("*");
+            builder.Table("People", "p", null);
+
+            return builder;
+        }
+
+        [Fact]
+        public void CloneShouldPreserveDistinct()
+        {
+            var builder = CreateSelectBuilder();
+            builder.Distinct();
+
+            var clone = builder.Clone();
+
+            Assert.Contains("DISTINCT", clone.ToSqlString());
+        }
+
+        [Fact]
+        public void CloneShouldNotAddDistinctWhenSourceHasNone()
+        {
+            var builder = CreateSelectBuilder();
+
+            var clone = builder.Clone();
+
+            Assert.DoesNotContain("DISTINCT", clone.ToSqlString());
+        }
+
+        [Fact]
+        public void CloneShouldBeIsolatedFromSource()
+        {
+            var builder = CreateSelectBuilder();
+
+            var clone = builder.Clone();
+
+            // Mutating the source after cloning must not affect the clone.
+            builder.Distinct();
+
+            Assert.DoesNotContain("DISTINCT", clone.ToSqlString());
+            Assert.Contains("DISTINCT", builder.ToSqlString());
+        }
+    }
+}

--- a/test/YesSql.Tests/WorkerQueryKeyTests.cs
+++ b/test/YesSql.Tests/WorkerQueryKeyTests.cs
@@ -76,5 +76,23 @@ namespace YesSql.Tests
 
             Assert.False(key1.Equals(key2));
         }
+
+        [Fact]
+        public void KeysWithSameSingleIdShouldBeEqual()
+        {
+            var key1 = new WorkerQueryKey("prefix1", 1L);
+            var key2 = new WorkerQueryKey("prefix1", 1L);
+
+            Assert.True(key1.Equals(key2));
+        }
+
+        [Fact]
+        public void KeysWithDifferentSingleIdShouldNotBeEqual()
+        {
+            var key1 = new WorkerQueryKey("prefix1", 1L);
+            var key2 = new WorkerQueryKey("prefix1", 2L);
+
+            Assert.False(key1.Equals(key2));
+        }
     }
 }


### PR DESCRIPTION
## Why

A pre-release audit of the source surfaced a handful of correctness bugs and robustness issues worth fixing before a major release. Most are latent (cache collisions, off-by-one boundaries, swallowed exceptions) and would be hard to diagnose in production.

## What changed

**Correctness**
- **`WorkerQueryKey.Equals`** returned `true` for single-id keys without comparing the id, violating the `Equals`/`GetHashCode` contract and risking query-cache collisions. Now compares the id.
- **`NullableThumbprintFactory`** had an off-by-one bound check that let a type index needing 17 bits overflow its 16-bit field. Tightened to `>= MaxTypeIndex`.
- **`DeleteReduceIndexCommand`** and **`UpdateIndexCommand`** did not flow the `CancellationToken` into their `ExecuteAsync` calls. Now wrapped in `CommandDefinition` with the token.
- **`Session.BatchCommands`** forced a single command exceeding `CommandsPageSize`/`MaxParametersPerCommand` (for example a reduce-index update touching many documents) into a batch that fails at execution time. Such commands are now flushed and executed individually.
- **`SqlBuilder.Clone`** dropped `_distinct` and `_or`; clones now copy both (deep-copying `_or`).
- **`BaseCommandInterpreter`** emitted `DROP INDEX` after `ADD INDEX` and after column drops. Index operations are now ordered conventionally: drop indexes first, then column changes, add indexes last.

**Robustness**
- **`SchemaBuilder`** swallowed every exception when `ThrowOnError` was false (including `NullReferenceException` and `OperationCanceledException`). Its 10 catch blocks now swallow only `DbException`, so the "already exists" semantics are preserved while programming errors and cancellation propagate.
- **`QueryFilterVisitor`** threw an opaque `NullReferenceException` when a term had no match/not-match predicate. It now throws a clear `InvalidOperationException`.

## Notes for reviewers

- The ALTER ordering change alters the order of statements emitted within a single `AlterTable`. Valid migrations should not depend on the previous relative ordering, but it is a behavior change worth a look.
- **Identifier length** (Postgres 63 / MySQL 64) was investigated and needs no change: `AlterTableCommand.CreateIndex`/`DropIndex` already apply `FormatIndexName`, and FK names use `FormatKeyName`.

## Tests

Added DB-independent unit tests for `SqlBuilder.Clone`, ALTER TABLE index ordering, the filter-visitor guard, and `WorkerQueryKey` equality. Each new test was verified to fail against the un-fixed code and pass with the fix. The thumbprint off-by-one, batch overflow, cancellation tokens, and schema catch narrowing are not unit-tested here: the first needs 65,536 registered types to hit the boundary, and the rest require live-DB integration infrastructure.

All existing tests still pass (the only failing SQLite tests, `AllDataTypes*`, are pre-existing on `main` and unrelated to this change).