### PR TITLE
Performance: faster query translation, SQLite writes, and SQL statement caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ project.lock.json
 .testPublish/ 
 .idea
 yessql.db
+
+# BenchmarkDotNet output
+BenchmarkDotNet.Artifacts/

--- a/samples/YesSql.Samples.Performance/Benchmarks.cs
+++ b/samples/YesSql.Samples.Performance/Benchmarks.cs
@@ -275,7 +275,7 @@ namespace YesSql.Samples.Performance
         }
 
         #region Names
-        private static readonly string[] Names = new[]
+        internal static readonly string[] Names = new[]
         {
             "MARY", "PATRICIA", "LINDA", "BARBARA", "ELIZABETH", "JENNIFER", "MARIA", "SUSAN", "MARGARET", "DOROTHY", "LISA",
             "NANCY", "KAREN", "BETTY", "HELEN", "SANDRA", "DONNA", "CAROL", "RUTH", "SHARON", "MICHELLE", "LAURA", "SARAH",

--- a/samples/YesSql.Samples.Performance/Program.cs
+++ b/samples/YesSql.Samples.Performance/Program.cs
@@ -6,7 +6,7 @@ namespace YesSql.Samples.Performance
     {
         static void Main(string[] args)
         {
-            var summary = BenchmarkRunner.Run<Benchmarks>();
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
         }
     }
 }

--- a/samples/YesSql.Samples.Performance/SqliteBenchmarks.cs
+++ b/samples/YesSql.Samples.Performance/SqliteBenchmarks.cs
@@ -1,0 +1,185 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using YesSql.Provider.Sqlite;
+using YesSql.Services;
+using YesSql.Sql;
+
+namespace YesSql.Samples.Performance
+{
+    [MemoryDiagnoser, ShortRunJob]
+    public class SqliteBenchmarks
+    {
+        private readonly Consumer _consumer = new();
+        private IStore _store;
+        private string _dbPath;
+        private string _connectionString;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            InitializeAsync().GetAwaiter().GetResult();
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            try
+            {
+                Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+                if (_dbPath != null && File.Exists(_dbPath))
+                {
+                    File.Delete(_dbPath);
+                }
+            }
+            catch { }
+        }
+
+        private async Task InitializeAsync()
+        {
+            _dbPath = Path.Combine(Path.GetTempPath(), $"yessql-bench-{Guid.NewGuid():N}.db");
+            _connectionString = $"Data Source={_dbPath};Cache=Shared";
+
+            var configuration = new Configuration()
+                .UseSqLite(_connectionString)
+                .SetTablePrefix("Perf");
+
+            _store = await StoreFactory.CreateAndInitializeAsync(configuration);
+
+            await using (var connection = configuration.ConnectionFactory.CreateConnection())
+            {
+                await connection.OpenAsync();
+
+                await using var transaction = await connection.BeginTransactionAsync();
+                var builder = new SchemaBuilder(configuration, transaction);
+
+                await builder.CreateMapIndexTableAsync<UserByName>(table => table
+                    .Column<string>("Name")
+                );
+
+                await builder.AlterTableAsync("UserByName", table => table
+                    .CreateIndex("IX_Name", "Name")
+                );
+
+                await transaction.CommitAsync();
+            }
+
+            _store.RegisterIndexes<UserIndexProvider>();
+
+            await CreateUsersAsync();
+        }
+
+        private async Task CreateUsersAsync()
+        {
+            var batch = 0;
+            const int batchSize = 128;
+            var session = _store.CreateSession();
+            foreach (var name in Names)
+            {
+                batch++;
+                await session.SaveAsync(new User
+                {
+                    Email = name + "@" + name + ".name",
+                    Name = name
+                });
+
+                if (batch % batchSize == 0)
+                {
+                    await session.SaveChangesAsync();
+                    await session.DisposeAsync();
+                    session = _store.CreateSession();
+                }
+            }
+
+            await session.SaveChangesAsync();
+            await session.DisposeAsync();
+        }
+
+        [Benchmark]
+        public ISession CreateSession()
+        {
+            using var session = _store.CreateSession();
+            return session;
+        }
+
+        [Benchmark]
+        public async Task WriteDocuments()
+        {
+            await using var session = _store.CreateSession();
+            for (var i = 0; i < 128; i++)
+            {
+                var name = Names[i];
+                await session.SaveAsync(new User
+                {
+                    Email = name + "@" + name + ".name",
+                    Name = name
+                });
+            }
+
+            await session.SaveChangesAsync();
+        }
+
+        [Benchmark]
+        public async Task QueryIndexByName()
+        {
+            var rnd = new Random(1);
+            var names = Enumerable.Range(1, 10).Select(x => Names[rnd.Next(Names.Length - 1)]).ToArray();
+
+            await using var session = _store.CreateSession();
+            foreach (var user in await session.QueryIndex<UserByName>(x => x.Name.IsIn(names)).ListAsync())
+            {
+                _consumer.Consume(user);
+            }
+        }
+
+        [Benchmark]
+        public async Task QueryByName()
+        {
+            var rnd = new Random(1);
+            var names = Enumerable.Range(1, 10).Select(x => Names[rnd.Next(Names.Length - 1)]).ToArray();
+
+            await using var session = _store.CreateSession();
+            foreach (var user in await session.Query<User, UserByName>(x => x.Name.IsIn(names)).ListAsync())
+            {
+                _consumer.Consume(user);
+            }
+        }
+
+        [Benchmark]
+        public async Task QueryLinqSingle()
+        {
+            var rnd = new Random(1);
+            var name = Names[rnd.Next(Names.Length - 1)];
+
+            await using var session = _store.CreateSession();
+            foreach (var user in await session.QueryIndex<UserByName>(x => x.Name == name).ListAsync())
+            {
+                _consumer.Consume(user);
+            }
+        }
+
+        [Benchmark]
+        public async Task QueryFirstOrDefault()
+        {
+            var rnd = new Random(1);
+            var name = Names[rnd.Next(Names.Length - 1)];
+
+            await using var session = _store.CreateSession();
+            var user = await session.Query<User, UserByName>(x => x.Name == name).FirstOrDefaultAsync();
+            _consumer.Consume(user);
+        }
+
+        [Benchmark]
+        public async Task CountAll()
+        {
+            await using var session = _store.CreateSession();
+            var count = await session.QueryIndex<UserByName>().CountAsync();
+            _consumer.Consume(count);
+        }
+
+        private static readonly string[] Names = Benchmarks.Names;
+    }
+}

--- a/samples/YesSql.Samples.Performance/YesSql.Samples.Performance.csproj
+++ b/samples/YesSql.Samples.Performance/YesSql.Samples.Performance.csproj
@@ -17,5 +17,6 @@
         <ProjectReference Include="..\..\src\YesSql.Core\YesSql.Core.csproj" />
         <ProjectReference Include="..\..\src\YesSql.Provider.PostgreSql\YesSql.Provider.PostgreSql.csproj" />
         <ProjectReference Include="..\..\src\YesSql.Provider.SqlServer\YesSql.Provider.SqlServer.csproj" />
+        <ProjectReference Include="..\..\src\YesSql.Provider.Sqlite\YesSql.Provider.Sqlite.csproj" />
     </ItemGroup>
 </Project>

--- a/src/YesSql.Core/Commands/CreateDocumentCommand.cs
+++ b/src/YesSql.Core/Commands/CreateDocumentCommand.cs
@@ -21,9 +21,7 @@ namespace YesSql.Commands
 
         public override Task ExecuteAsync(DbConnection connection, DbTransaction transaction, ISqlDialect dialect, ILogger logger, CancellationToken cancellationToken = default)
         {
-            var documentTable = _store.Configuration.TableNameConvention.GetDocumentTable(Collection);
-
-            var insertCmd = $"insert into {dialect.QuoteForTableName(_store.Configuration.TablePrefix + documentTable, _store.Configuration.Schema)} ({dialect.QuoteForColumnName("Id")}, {dialect.QuoteForColumnName("Type")}, {dialect.QuoteForColumnName("Content")}, {dialect.QuoteForColumnName("Version")}) values (@Id, @Type, @Content, @Version);";
+            var insertCmd = GetInsertCommandText(dialect, _store, Collection);
 
             if (logger.IsEnabled(LogLevel.Trace))
             {

--- a/src/YesSql.Core/Commands/CreateIndexCommand.cs
+++ b/src/YesSql.Core/Commands/CreateIndexCommand.cs
@@ -30,8 +30,7 @@ namespace YesSql.Commands
             var type = Index.GetType();
             var documentTable = _store.Configuration.TableNameConvention.GetDocumentTable(Collection);
 
-            var sql = Inserts(type, dialect);
-            sql = sql.Replace(ParameterSuffix, "");
+            var sql = InsertsForExecute(type, dialect);
 
             if (logger.IsEnabled(LogLevel.Trace))
             {

--- a/src/YesSql.Core/Commands/DeleteDocumentCommand.cs
+++ b/src/YesSql.Core/Commands/DeleteDocumentCommand.cs
@@ -20,9 +20,8 @@ namespace YesSql.Commands
 
         public override Task ExecuteAsync(DbConnection connection, DbTransaction transaction, ISqlDialect dialect, ILogger logger, CancellationToken cancellationToken = default)
         {
-            var documentTable = _store.Configuration.TableNameConvention.GetDocumentTable(Collection);
-            var deleteCmd = $"delete from {dialect.QuoteForTableName(_store.Configuration.TablePrefix + documentTable, _store.Configuration.Schema)} where {dialect.QuoteForColumnName("Id")} = @Id;";
-            
+            var deleteCmd = GetDeleteCommandText(dialect, _store, Collection);
+
             if (logger.IsEnabled(LogLevel.Trace))
             {
                 logger.LogTrace(deleteCmd);

--- a/src/YesSql.Core/Commands/DocumentCommand.cs
+++ b/src/YesSql.Core/Commands/DocumentCommand.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Reflection;
@@ -20,6 +21,10 @@ namespace YesSql.Commands
             typeof(Document).GetProperty("Id")
         };
 
+        private static readonly ConcurrentDictionary<DocumentCommandKey, string> InsertCommands = new();
+        private static readonly ConcurrentDictionary<DocumentCommandKey, string> UpdateCommands = new();
+        private static readonly ConcurrentDictionary<DocumentCommandKey, string> DeleteCommands = new();
+
         public abstract int ExecutionOrder { get; }
 
         protected DocumentCommand(Document document, string collection)
@@ -35,5 +40,71 @@ namespace YesSql.Commands
         public abstract Task ExecuteAsync(DbConnection connection, DbTransaction transaction, ISqlDialect dialect, ILogger logger, CancellationToken cancellationToken = default);
 
         public abstract bool AddToBatch(ISqlDialect dialect, List<string> queries, DbCommand parameters, List<Action<DbDataReader>> actions, int index);
+
+        /// <summary>
+        /// Clears the cached document SQL statements. Invoked when a store is (re)initialized.
+        /// </summary>
+        public static void ResetQueryCache()
+        {
+            InsertCommands.Clear();
+            UpdateCommands.Clear();
+            DeleteCommands.Clear();
+        }
+
+        /// <summary>
+        /// Returns the cached <c>insert</c> statement for a document table. The statement only depends on
+        /// the dialect, schema, table prefix and collection, so it can be reused across commands.
+        /// </summary>
+        protected static string GetInsertCommandText(ISqlDialect dialect, IStore store, string collection)
+        {
+            var key = new DocumentCommandKey(dialect.Name, store.Configuration.Schema, store.Configuration.TablePrefix, collection);
+
+            if (!InsertCommands.TryGetValue(key, out var result))
+            {
+                var documentTable = store.Configuration.TableNameConvention.GetDocumentTable(collection);
+
+                InsertCommands[key] = result = $"insert into {dialect.QuoteForTableName(store.Configuration.TablePrefix + documentTable, store.Configuration.Schema)} ({dialect.QuoteForColumnName("Id")}, {dialect.QuoteForColumnName("Type")}, {dialect.QuoteForColumnName("Content")}, {dialect.QuoteForColumnName("Version")}) values (@Id, @Type, @Content, @Version);";
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Returns the cached <c>update</c> statement (without the optional version check clause) for a document table.
+        /// </summary>
+        protected static string GetUpdateCommandText(ISqlDialect dialect, IStore store, string collection)
+        {
+            var key = new DocumentCommandKey(dialect.Name, store.Configuration.Schema, store.Configuration.TablePrefix, collection);
+
+            if (!UpdateCommands.TryGetValue(key, out var result))
+            {
+                var documentTable = store.Configuration.TableNameConvention.GetDocumentTable(collection);
+
+                UpdateCommands[key] = result = $"update {dialect.QuoteForTableName(store.Configuration.TablePrefix + documentTable, store.Configuration.Schema)} "
+                    + $"set {dialect.QuoteForColumnName("Content")} = @Content, {dialect.QuoteForColumnName("Version")} = @Version where "
+                    + $"{dialect.QuoteForColumnName("Id")} = @Id ";
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Returns the cached <c>delete</c> statement for a document table.
+        /// </summary>
+        protected static string GetDeleteCommandText(ISqlDialect dialect, IStore store, string collection)
+        {
+            var key = new DocumentCommandKey(dialect.Name, store.Configuration.Schema, store.Configuration.TablePrefix, collection);
+
+            if (!DeleteCommands.TryGetValue(key, out var result))
+            {
+                var documentTable = store.Configuration.TableNameConvention.GetDocumentTable(collection);
+
+                DeleteCommands[key] = result = $"delete from {dialect.QuoteForTableName(store.Configuration.TablePrefix + documentTable, store.Configuration.Schema)} where {dialect.QuoteForColumnName("Id")} = @Id;";
+            }
+
+            return result;
+        }
+
+        private sealed record DocumentCommandKey(string Dialect, string Schema, string Prefix, string Collection);
     }
 }

--- a/src/YesSql.Core/Commands/IndexCommand.cs
+++ b/src/YesSql.Core/Commands/IndexCommand.cs
@@ -24,6 +24,8 @@ namespace YesSql.Commands
         private static readonly ConcurrentDictionary<string, PropertyInfo[]> TypeProperties = new();
         private static readonly ConcurrentDictionary<CompoundKey, string> InsertsList = new();
         private static readonly ConcurrentDictionary<CompoundKey, string> UpdatesList = new();
+        private static readonly ConcurrentDictionary<CompoundKey, string> ExecuteInsertsList = new();
+        private static readonly ConcurrentDictionary<CompoundKey, string> ExecuteUpdatesList = new();
 
         protected static readonly PropertyInfo[] KeysProperties = new[] { typeof(IIndex).GetProperty("Id") };
 
@@ -46,6 +48,8 @@ namespace YesSql.Commands
         {
             InsertsList.Clear();
             UpdatesList.Clear();
+            ExecuteInsertsList.Clear();
+            ExecuteUpdatesList.Clear();
         }
 
         protected static void GetProperties(DbCommand command, object item, string suffix, ISqlDialect dialect)
@@ -174,6 +178,49 @@ namespace YesSql.Commands
                 }
 
                 UpdatesList[key] = result = $"update {dialect.QuoteForTableName(_store.Configuration.TablePrefix + _store.Configuration.TableNameConvention.GetIndexTable(type, Collection), _store.Configuration.Schema)} set {values} where {dialect.QuoteForColumnName("Id")} = @Id{ParameterSuffix};";
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Returns the <c>insert</c> statement used when a command is executed individually (not batched).
+        /// The parameter suffix placeholder is removed once and the result cached, so the per-row
+        /// <see cref="string.Replace(string, string)"/> is avoided on the hot write path.
+        /// </summary>
+        protected string InsertsForExecute(Type type, ISqlDialect dialect)
+        {
+            var key = new CompoundKey(
+                dialect.Name,
+                type.FullName,
+                _store.Configuration.Schema,
+                _store.Configuration.TablePrefix,
+                Collection);
+
+            if (!ExecuteInsertsList.TryGetValue(key, out var result))
+            {
+                ExecuteInsertsList[key] = result = Inserts(type, dialect).Replace(ParameterSuffix, "");
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Returns the <c>update</c> statement used when a command is executed individually (not batched).
+        /// The parameter suffix placeholder is removed once and the result cached.
+        /// </summary>
+        protected string UpdatesForExecute(Type type, ISqlDialect dialect)
+        {
+            var key = new CompoundKey(
+                dialect.Name,
+                type.FullName,
+                _store.Configuration.Schema,
+                _store.Configuration.TablePrefix,
+                Collection);
+
+            if (!ExecuteUpdatesList.TryGetValue(key, out var result))
+            {
+                ExecuteUpdatesList[key] = result = Updates(type, dialect).Replace(ParameterSuffix, "");
             }
 
             return result;

--- a/src/YesSql.Core/Commands/UpdateDocumentCommand.cs
+++ b/src/YesSql.Core/Commands/UpdateDocumentCommand.cs
@@ -23,11 +23,7 @@ namespace YesSql.Commands
 
         public override async Task ExecuteAsync(DbConnection connection, DbTransaction transaction, ISqlDialect dialect, ILogger logger, CancellationToken cancellationToken = default)
         {
-            var documentTable = _store.Configuration.TableNameConvention.GetDocumentTable(Collection);
-
-            var updateCmd = $"update {dialect.QuoteForTableName(_store.Configuration.TablePrefix + documentTable, _store.Configuration.Schema)} "
-                + $"set {dialect.QuoteForColumnName("Content")} = @Content, {dialect.QuoteForColumnName("Version")} = @Version where "
-                + $"{dialect.QuoteForColumnName("Id")} = @Id "
+            var updateCmd = GetUpdateCommandText(dialect, _store, Collection)
                 + (_checkVersion > -1
                     ? Document.Version == 1 // When the Document.Version is 0 + 1 the Version column maybe null.
                         ? $" and ({dialect.QuoteForColumnName("Version")} IS NULL OR {dialect.QuoteForColumnName("Version")} = {dialect.GetSqlValue(_checkVersion)}) ;"

--- a/src/YesSql.Core/Commands/UpdateIndexCommand.cs
+++ b/src/YesSql.Core/Commands/UpdateIndexCommand.cs
@@ -32,8 +32,7 @@ namespace YesSql.Commands
         {
             var type = Index.GetType();
 
-            var sql = Updates(type, dialect);
-            sql = sql.Replace(ParameterSuffix, "");
+            var sql = UpdatesForExecute(type, dialect);
             if (logger.IsEnabled(LogLevel.Trace))
             {
                 logger.LogTrace(sql);

--- a/src/YesSql.Core/Provider/BaseDialect.cs
+++ b/src/YesSql.Core/Provider/BaseDialect.cs
@@ -312,18 +312,20 @@ namespace YesSql.Provider
             for (var i = 0; i < orderBy.Count; i++)
             {
                 var o = orderBy[i];
-                var next = i + 1 < orderBy.Count ? orderBy[i + 1].Trim() : null;
-                var trimmed = o.Trim();
+                var next = i + 1 < orderBy.Count ? orderBy[i + 1].AsSpan().Trim() : default;
+                var trimmed = o.AsSpan().Trim();
                 var alias = QuoteForAliasName("order_" + index++);
 
                 // Each order segment can be a field name, or a punctuation, so we filter out the punctuations 
-                if (trimmed != "," && trimmed != "DESC" && trimmed != "ASC")
+                if (!trimmed.Equals(",", StringComparison.Ordinal)
+                    && !trimmed.Equals("DESC", StringComparison.Ordinal)
+                    && !trimmed.Equals("ASC", StringComparison.Ordinal))
                 {
                     var aggregate = $"MAX({o}) AS {alias}";
 
-                    if (next == "DESC" || next == "ASC")
+                    if (next.Equals("DESC", StringComparison.Ordinal) || next.Equals("ASC", StringComparison.Ordinal))
                     {
-                        alias += " " + next;
+                        alias += " " + next.ToString();
                     }
 
                     result.Add((aggregate, alias));

--- a/src/YesSql.Core/Services/DefaultQuery.cs
+++ b/src/YesSql.Core/Services/DefaultQuery.cs
@@ -294,7 +294,7 @@ namespace YesSql.Services
                 static (query, builder, dialect, expression) =>
                 {
                     // Could be simplified if int[] could be casted to IEnumerable<object>
-                    var objects = Expression.Lambda(expression.Arguments[1]).Compile().DynamicInvoke() as IEnumerable;
+                    var objects = GetExpressionValue(expression.Arguments[1]) as IEnumerable;
                     var values = new List<object>();
 
                     foreach (var o in objects)
@@ -335,7 +335,7 @@ namespace YesSql.Services
                 static (query, builder, dialect, expression) =>
                 {
                     // Could be simplified if int[] could be casted to IEnumerable<object>
-                    var objects = Expression.Lambda(expression.Arguments[1]).Compile().DynamicInvoke() as IEnumerable;
+                    var objects = GetExpressionValue(expression.Arguments[1]) as IEnumerable;
                     var values = new List<object>();
 
                     foreach (var o in objects)
@@ -550,6 +550,41 @@ namespace YesSql.Services
         /// <summary>
         /// Converts an expression that is not based on a lambda parameter to its atomic constant value.
         /// </summary>
+        // Reads the runtime value of an expression without compiling a lambda for the common
+        // cases (constants and field/property access on closures or constants). Falls back to
+        // compiling only for shapes that aren't handled here. Unlike <see cref="Evaluate"/>, this
+        // has no side effects (it doesn't register parameter bindings) and is used when the value
+        // is inlined rather than parameterized for a compiled query.
+        private static object GetExpressionValue(Expression expression)
+        {
+            switch (expression.NodeType)
+            {
+                case ExpressionType.Constant:
+                    return ((ConstantExpression)expression).Value;
+
+                case ExpressionType.Convert:
+                    return GetExpressionValue(((UnaryExpression)expression).Operand);
+
+                case ExpressionType.MemberAccess:
+                    var memberExpression = (MemberExpression)expression;
+                    var instance = memberExpression.Expression == null
+                        ? null
+                        : GetExpressionValue(memberExpression.Expression);
+
+                    switch (memberExpression.Member)
+                    {
+                        case FieldInfo field:
+                            return field.GetValue(instance);
+                        case PropertyInfo property:
+                            return property.GetValue(instance);
+                    }
+
+                    break;
+            }
+
+            return Expression.Lambda(expression).Compile().DynamicInvoke();
+        }
+
         private ConstantExpression Evaluate(Expression expression, bool convertValue = true)
         {
             switch (expression.NodeType)

--- a/src/YesSql.Core/Session.cs
+++ b/src/YesSql.Core/Session.cs
@@ -865,6 +865,11 @@ namespace YesSql
                 return;
             }
 
+            // The number of commands per batch is capped by the configured page size and by the
+            // maximum the dialect allows (some providers can only batch a limited number of
+            // statements efficiently). A dialect that doesn't impose a cap returns int.MaxValue.
+            var commandsPageSize = Math.Min(_store.Configuration.CommandsPageSize, _dialect.MaxCommandsPageSize);
+
             var batches = new List<IIndexCommand>();
 
             // holds the queries, parameters and actions returned by an IIndexCommand, until we know we can
@@ -885,7 +890,7 @@ namespace YesSql
                 {
                     // Does it go over the page or parameters limits
 
-                    var tooManyQueries = batch.Queries.Count + localQueries.Count > _store.Configuration.CommandsPageSize;
+                    var tooManyQueries = batch.Queries.Count + localQueries.Count > commandsPageSize;
                     var tooManyCommands = batch.Command.Parameters.Count + localDbCommand.Parameters.Count > _store.Configuration.SqlDialect.MaxParametersPerCommand;
 
                     if (tooManyQueries || tooManyCommands)

--- a/src/YesSql.Core/Store.cs
+++ b/src/YesSql.Core/Store.cs
@@ -88,6 +88,7 @@ namespace YesSql
         public async Task InitializeAsync(CancellationToken cancellationToken = default)
         {
             IndexCommand.ResetQueryCache();
+            DocumentCommand.ResetQueryCache();
             ValidateConfiguration();
 
             TypeNames = new TypeService();

--- a/src/YesSql.Provider.Sqlite/SqliteDialect.cs
+++ b/src/YesSql.Provider.Sqlite/SqliteDialect.cs
@@ -214,19 +214,21 @@ namespace YesSql.Provider.Sqlite
             for (var i = 0; i < orderBy.Count; i++)
             {
                 var o = orderBy[i];
-                var next = i + 1 < orderBy.Count ? orderBy[i + 1].Trim() : null;
-                var trimmed = o.Trim();
+                var next = i + 1 < orderBy.Count ? orderBy[i + 1].AsSpan().Trim() : default;
+                var trimmed = o.AsSpan().Trim();
                 var alias = QuoteForAliasName("order_" + index++);
 
                 // Each order segment can be a field name, or a punctuation, so we filter out the punctuations 
-                if (trimmed != "," && trimmed != "DESC" && trimmed != "ASC")
+                if (!trimmed.Equals(",", StringComparison.Ordinal)
+                    && !trimmed.Equals("DESC", StringComparison.Ordinal)
+                    && !trimmed.Equals("ASC", StringComparison.Ordinal))
                 {
                     // Don't aggregate the order field in Sqlite
                     var aggregate = $"{o} AS {alias}";
 
-                    if (next == "DESC" || next == "ASC")
+                    if (next.Equals("DESC", StringComparison.Ordinal) || next.Equals("ASC", StringComparison.Ordinal))
                     {
-                        alias += " " + next;
+                        alias += " " + next.ToString();
                     }
 
                     result.Add((aggregate, alias));

--- a/src/YesSql.Provider.Sqlite/SqliteDialect.cs
+++ b/src/YesSql.Provider.Sqlite/SqliteDialect.cs
@@ -187,6 +187,16 @@ namespace YesSql.Provider.Sqlite
         public override bool SupportsIfExistsBeforeTableName => true;
 
         /// <inheritdoc />
+        /// <remarks>
+        /// Batching is disabled for SQLite. SQLite runs in-process, so grouping many statements
+        /// into a single command provides no round-trip savings. Worse, Microsoft.Data.Sqlite binds
+        /// every parameter of the command to every statement it contains, making parameter binding
+        /// O(statements × parameters). For large batches this dominates both CPU and allocations.
+        /// Executing the commands individually is significantly faster and allocates far less.
+        /// </remarks>
+        public override bool SupportsBatching => false;
+
+        /// <inheritdoc />
         public override string GetCreateSchemaString(string schema)
         {
             return null;

--- a/test/YesSql.Tests/AggregateOrdersTests.cs
+++ b/test/YesSql.Tests/AggregateOrdersTests.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using YesSql.Provider.SqlServer;
+
+namespace YesSql.Tests
+{
+    // Covers BaseDialect.GetAggregateOrders, which is used by the SqlServer, PostgreSql and MySql
+    // dialects (Sqlite overrides it). These run with no database connection.
+    public class AggregateOrdersTests
+    {
+        [Fact]
+        public void ShouldAggregateOrderedFields()
+        {
+            var dialect = new SqlServerDialect();
+
+            var result = dialect.GetAggregateOrders(new List<string> { "[col]" }, new List<string> { "[col]" }).ToList();
+
+            var (aggregate, alias) = Assert.Single(result);
+            Assert.Equal("MAX([col]) AS [order_1]", aggregate);
+            Assert.Equal("[order_1]", alias);
+        }
+
+        [Fact]
+        public void ShouldAttachDirectionToAlias()
+        {
+            var dialect = new SqlServerDialect();
+
+            var result = dialect.GetAggregateOrders(new List<string> { "[col]" }, new List<string> { "[col]", "DESC" }).ToList();
+
+            var (aggregate, alias) = Assert.Single(result);
+            Assert.Equal("MAX([col]) AS [order_1]", aggregate);
+            Assert.Equal("[order_1] DESC", alias);
+        }
+
+        [Fact]
+        public void ShouldSkipPunctuationAndTrimWhitespace()
+        {
+            var dialect = new SqlServerDialect();
+
+            // Order segments can contain surrounding whitespace and comma separators that must be ignored.
+            var orderBy = new List<string> { " [a] ", " , ", " [b] ", " ASC " };
+            var result = dialect.GetAggregateOrders(new List<string> { "[a]", "[b]" }, orderBy).ToList();
+
+            Assert.Equal(2, result.Count);
+            Assert.Equal("MAX( [a] ) AS [order_1]", result[0].aggregate);
+            Assert.Equal("[order_1]", result[0].alias);
+            Assert.Equal("MAX( [b] ) AS [order_3]", result[1].aggregate);
+            Assert.Equal("[order_3] ASC", result[1].alias);
+        }
+    }
+}


### PR DESCRIPTION
## Why

A profiling pass over the hot paths, measured locally with SQLite benchmarks, surfaced three avoidable costs: query translation compiled a lambda on every `IsIn`/`IsNotIn`, document writes allocated and spent disproportionate time inside SQLite batching, and the document commands rebuilt their SQL string on every execution.

## What changed

**Query translation (`DefaultQuery`)** — `IsIn`/`IsNotIn` previously called `Expression.Lambda(...).Compile().DynamicInvoke()` on every query to read the operand value. Replaced with a side-effect-free `GetExpressionValue` helper that reads constants and field/property access directly, falling back to compilation only for uncommon expression shapes. Existing `Evaluate` could not be reused because it registers parameter bindings (side effects) and these values are inlined.

**SQLite write path (`SqliteDialect`)** — Disabled command batching for SQLite (`SupportsBatching => false`). SQLite runs in-process, so grouping statements into one command saves no round-trips, and Microsoft.Data.Sqlite binds every parameter to every statement in a batch (O(statements x parameters)). Executing commands individually through their existing, well-tested `ExecuteAsync` path is dramatically faster and allocates far less. This is deliberately scoped to SQLite; the network providers (SqlServer, PostgreSQL, MySQL) still benefit from batching's round-trip savings and are unchanged.

**Document SQL caching (`DocumentCommand` + Create/Update/Delete)** — The insert/update/delete statements were rebuilt (string interpolation + repeated `QuoteForColumnName`/`QuoteForTableName` calls) on every execute. They are now cached per `(dialect, schema, prefix, collection)` in the base class, mirroring the existing `IndexCommand` pattern, and the cache is cleared on store initialization.

**Wire up `MaxCommandsPageSize` (`Session`)** — This dialect property was declared but never consumed. The batch page size is now capped by `min(Configuration.CommandsPageSize, dialect.MaxCommandsPageSize)`, giving providers a per-dialect ceiling on batch size. All dialects currently return `int.MaxValue`, so behavior is unchanged; this just lights up the latent knob as a middle ground between full batching and the SQLite opt-out.

## Measured results (SQLite, net10.0)

| Benchmark | Before | After | Delta |
|---|---|---|---|
| WriteDocuments (time) | 37.8 ms | 5.9 ms | -84% |
| WriteDocuments (alloc) | 85 MB | 0.8 MB | -99% |
| QueryIndexByName (time) | 46 us | 20 us | -57% |
| QueryByName (time) | 58 us | 33 us | -43% |

Other benchmarks (CreateSession, QueryLinqSingle, QueryFirstOrDefault, CountAll) are unchanged.

## Notes for reviewers

- The benchmark harness gains a `SqliteBenchmarks` class and switches `Program` to `BenchmarkSwitcher` so individual providers can be filtered. `BenchmarkDotNet.Artifacts/` is added to `.gitignore`.
- The SQLite batching change is a behavioral change for all SQLite users, but the data strongly supports it and all 195 SQLite tests pass, including `ShouldSplitBatchCommandsByMaxParameters` and the batch delete/update tests.
- The network providers were not benchmarked because they require running database servers; the instruction was to measure locally with SQLite. Their batching paths are intentionally left as-is.