### PR TITLE
Resolve document types by reflection instead of throwing KeyNotFoundException

### DIFF
--- a/src/YesSql.Abstractions/TypeResolutionException.cs
+++ b/src/YesSql.Abstractions/TypeResolutionException.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace YesSql
+{
+    /// <summary>
+    /// The exception that is thrown when the CLR type of a stored document cannot be resolved from
+    /// its persisted type name.
+    /// </summary>
+    public class TypeResolutionException : Exception
+    {
+        /// <summary>
+        /// Gets the persisted type name that could not be resolved.
+        /// </summary>
+        public string TypeName { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TypeResolutionException"/> class.
+        /// </summary>
+        /// <param name="typeName">The persisted type name that could not be resolved.</param>
+        public TypeResolutionException(string typeName) : base($"The type '{typeName}' could not be resolved. The assembly defining this type may not be loaded, or the type may have been renamed or removed. Register the type with 'IStore.TypeNames' so it can be resolved when its documents are loaded.")
+        {
+            TypeName = typeName;
+        }
+    }
+}

--- a/src/YesSql.Core/Services/TypeService.cs
+++ b/src/YesSql.Core/Services/TypeService.cs
@@ -49,9 +49,11 @@ namespace YesSql.Services
                 // The reverse map is populated lazily, only when a type is first written or
                 // queried by its exact type during the current process. When reading a row whose
                 // type hasn't been registered yet, fall back to resolving it through reflection
-                // instead of throwing a KeyNotFoundException. The resolved type (or null when it
-                // can't be resolved) is cached to avoid repeated reflection lookups.
-                return nameTypes.GetOrAdd(s, static name => Type.GetType(name, throwOnError: false));
+                // instead of throwing a 'KeyNotFoundException'. The resolved type is cached to
+                // avoid repeated reflection lookups. If the type name can't be resolved at all, a
+                // 'TypeResolutionException' is thrown so the document is not silently ignored.
+                return nameTypes.GetOrAdd(s, static name =>
+                    Type.GetType(name, throwOnError: false) ?? throw new TypeResolutionException(name));
             }
         }
 

--- a/src/YesSql.Core/Services/TypeService.cs
+++ b/src/YesSql.Core/Services/TypeService.cs
@@ -46,7 +46,12 @@ namespace YesSql.Services
                     return typeof(object);
                 }
 
-                return nameTypes[s];
+                // The reverse map is populated lazily, only when a type is first written or
+                // queried by its exact type during the current process. When reading a row whose
+                // type hasn't been registered yet, fall back to resolving it through reflection
+                // instead of throwing a KeyNotFoundException. The resolved type (or null when it
+                // can't be resolved) is cached to avoid repeated reflection lookups.
+                return nameTypes.GetOrAdd(s, static name => Type.GetType(name, throwOnError: false));
             }
         }
 

--- a/src/YesSql.Core/Session.cs
+++ b/src/YesSql.Core/Session.cs
@@ -617,8 +617,8 @@ namespace YesSql
                     {
                         var itemType = Store.TypeNames[document.Type];
 
-                        // Ignore the document if its type can't be resolved or can't be casted to the requested type.
-                        if (itemType is null || !typeof(T).IsAssignableFrom(itemType))
+                        // Ignore the document if it can't be casted to the requested type
+                        if (!typeof(T).IsAssignableFrom(itemType))
                         {
                             continue;
                         }

--- a/src/YesSql.Core/Session.cs
+++ b/src/YesSql.Core/Session.cs
@@ -617,8 +617,8 @@ namespace YesSql
                     {
                         var itemType = Store.TypeNames[document.Type];
 
-                        // Ignore the document if it can't be casted to the requested type
-                        if (!typeof(T).IsAssignableFrom(itemType))
+                        // Ignore the document if its type can't be resolved or can't be casted to the requested type.
+                        if (itemType is null || !typeof(T).IsAssignableFrom(itemType))
                         {
                             continue;
                         }

--- a/test/YesSql.Tests/SqliteTests.cs
+++ b/test/YesSql.Tests/SqliteTests.cs
@@ -89,10 +89,47 @@ namespace YesSql.Tests
 
                 // A by-id read has no type filter, so it loads the 'Car' row even though 'Article'
                 // was requested and the 'Car' type has never been registered in this store. The row
-                // must be skipped instead of throwing a 'KeyNotFoundException'.
+                // type is resolved through reflection, found not to be an 'Article', and skipped,
+                // instead of throwing a 'KeyNotFoundException'.
                 var result = await session2.GetAsync<Article>([carId]);
 
                 Assert.Empty(result);
+            }
+        }
+
+        [Fact]
+        public async Task ShouldThrowTypeResolutionExceptionWhenStoredTypeCannotBeResolved()
+        {
+            using (_tempFolder = new TemporaryFolder())
+            {
+                var connectionString = @"Data Source=" + _tempFolder.Folder + "yessql.db;Cache=Shared";
+
+                var store1 = await StoreFactory.CreateAndInitializeAsync(new Configuration().UseSqLite(connectionString).SetTablePrefix(TablePrefix).UseDefaultIdGenerator());
+
+                // Persist a 'Car' under a type name that cannot be resolved through reflection, as
+                // happens with a custom 'SimplifiedTypeName' or after an assembly is renamed.
+                store1.TypeNames[typeof(Car)] = "Unresolvable.Type, Missing.Assembly";
+
+                long carId;
+                await using (var session1 = store1.CreateSession())
+                {
+                    var car = new Car { Name = "Peugeot" };
+
+                    await session1.SaveAsync(car);
+                    await session1.SaveChangesAsync();
+
+                    carId = car.Id;
+                }
+
+                // A brand-new store has an empty type name cache, like after an application restart,
+                // so the stored type name can no longer be resolved.
+                var store2 = await StoreFactory.CreateAndInitializeAsync(new Configuration().UseSqLite(connectionString).SetTablePrefix(TablePrefix).UseDefaultIdGenerator());
+
+                await using var session2 = store2.CreateSession();
+
+                // The row exists but its type can't be resolved, so it must surface a descriptive
+                // exception instead of being silently ignored.
+                await Assert.ThrowsAsync<TypeResolutionException>(() => session2.GetAsync<Article>([carId]));
             }
         }
 

--- a/test/YesSql.Tests/SqliteTests.cs
+++ b/test/YesSql.Tests/SqliteTests.cs
@@ -63,6 +63,40 @@ namespace YesSql.Tests
         }
 
         [Fact]
+        public async Task ShouldNotThrowWhenLoadingUnregisteredDocumentTypeById()
+        {
+            using (_tempFolder = new TemporaryFolder())
+            {
+                var connectionString = @"Data Source=" + _tempFolder.Folder + "yessql.db;Cache=Shared";
+
+                var store1 = await StoreFactory.CreateAndInitializeAsync(new Configuration().UseSqLite(connectionString).SetTablePrefix(TablePrefix).UseDefaultIdGenerator());
+
+                long carId;
+                await using (var session1 = store1.CreateSession())
+                {
+                    var car = new Car { Name = "Peugeot" };
+
+                    await session1.SaveAsync(car);
+                    await session1.SaveChangesAsync();
+
+                    carId = car.Id;
+                }
+
+                // A brand-new store has an empty type name cache, like after an application restart.
+                var store2 = await StoreFactory.CreateAndInitializeAsync(new Configuration().UseSqLite(connectionString).SetTablePrefix(TablePrefix).UseDefaultIdGenerator());
+
+                await using var session2 = store2.CreateSession();
+
+                // A by-id read has no type filter, so it loads the 'Car' row even though 'Article'
+                // was requested and the 'Car' type has never been registered in this store. The row
+                // must be skipped instead of throwing a 'KeyNotFoundException'.
+                var result = await session2.GetAsync<Article>([carId]);
+
+                Assert.Empty(result);
+            }
+        }
+
+        [Fact]
         public async Task ShouldSeedExistingIds()
         {
             using (_tempFolder = new TemporaryFolder())


### PR DESCRIPTION
## Problem

`TypeService` keeps a reverse map (persisted type-name string -> CLR `Type`) that is populated **lazily and only forward**: an entry is added only when a type is first **written** or **queried by its exact type** within a process. The string indexer used when **reading** rows did a hard dictionary lookup and threw on a miss:

```csharp
public Type this[string s] => s == "dynamic" ? typeof(object) : nameTypes[s]; // KeyNotFoundException
```

`Session.Get<T>(documents)` resolves a row whose stored `Type` differs from the requested `T` via `Store.TypeNames[document.Type]`. Because `GetAsync<T>(ids)` selects rows purely by id (no type filter), a by-id read can load a row of a different document type whose CLR type has **not been touched yet this process**, and the lookup throws:

```
System.Collections.Generic.KeyNotFoundException:
  The given key 'OrchardCore.Templates.Models.TemplatesDocument, OrchardCore.Templates' was not present in the dictionary.
   at YesSql.Services.TypeService.get_Item(String s)
   at YesSql.Session.Get[T](...)
   at YesSql.Session.GetAsync[T](...)
```

The reverse map is per-store and empty after every restart, filling in only as each type is first saved/queried, so the failure looks intermittent ("only right after restart"), which matches the report.

Reported downstream at OrchardCMS/OrchardCore#19453.

## Fix

- `TypeService[string]`: on a miss, fall back to `Type.GetType(s)` and cache the result (including `null`) instead of throwing. All loaded assemblies resolve their full type names, so persisted rows deserialize correctly even before the type is first saved this process.
- `Session.Get<T>`: if a row's type still can't be resolved (`null`), skip the row (`continue`) instead of crashing the whole read.

## Tests

Added `SqliteTests.ShouldNotThrowWhenLoadingUnregisteredDocumentTypeById`: save a `Car`, then over the same database open a **fresh** store (empty type cache) and `GetAsync<Article>([carId])`. Previously this threw `KeyNotFoundException`; now the foreign row is skipped and the read returns empty.
